### PR TITLE
TLS emergency fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+3.0.2
+- Support for TLS 1.2 on SDK HttpClient.
+
 3.0.1
 - Bug fixes.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 CHANGES
 
 3.0.2
-- Support for TLS 1.2 on SDK HttpClient.
+- Support for TLS 1.2 on SDK Net HttpClient.
 
 3.0.1
 - Bug fixes.

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,5 +1,8 @@
 NEWS
 
+3.0.2
+- Add support for TLS 1.2.
+
 3.0.1
 - No news for this update.
 

--- a/NetSDK/CommonLibraries/SdkApiClient.cs
+++ b/NetSDK/CommonLibraries/SdkApiClient.cs
@@ -16,6 +16,7 @@ namespace Splitio.CommonLibraries
 
         public SdkApiClient (HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null)
         {
+            ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
             if (header.encoding == "gzip")
             {
                 HttpClientHandler handler = new HttpClientHandler()

--- a/NetSDK/Version.cs
+++ b/NetSDK/Version.cs
@@ -3,7 +3,7 @@ namespace Splitio
 {
     public static class Version
     {
-        public static string SplitSdkVersion = "3.0.1";
+        public static string SplitSdkVersion = "3.0.2";
         public static string SplitSpecVersion = "1.0";
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 nuget:
   account_feed: true
 
-version: 3.0.1
+version: 3.0.2
 
 before_build:
  - nuget restore


### PR DESCRIPTION
@patricioe  @dendril 

Based on:

http://blogs.perficient.com/microsoft/2016/04/tsl-1-2-and-net-support/


.NET 4.0. TLS 1.2 is not supported, but if you have .NET 4.5 (or above) installed on the system then you still can opt in for TLS 1.2 even if your application framework doesn’t support it. The only problem is that SecurityProtocolType in .NET 4.0 doesn’t have an entry for TLS1.2, so we’d have to use a numerical representation of this enum value:

ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
