### PR TITLE
Implement fix in impressions listener configuration

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 CHANGES
 
+3.1.1
+- Bug fix.
+
 3.1.0
 - Support for new string and set matchers: ContainsAllOfSet, ContainsAnyOfSet, ContainsString, EndsWith, EqualToSet, PartOfSet and StartsWith
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,5 +1,8 @@
 NEWS
 
+3.1.1
+- No news for this update.
+
 3.1.0
 - Add support for new string and set matchers.
 

--- a/NetSDK/Services/Client/Classes/RedisClient.cs
+++ b/NetSDK/Services/Client/Classes/RedisClient.cs
@@ -120,7 +120,10 @@ namespace Splitio.Services.Client.Classes
             var treatmentLog = new RedisTreatmentLog(impressionsCache);
             impressionListener = new AsynchronousImpressionListener();
             ((AsynchronousImpressionListener)impressionListener).AddListener(treatmentLog);
-            ((AsynchronousImpressionListener)impressionListener).AddListener(config.ImpressionListener);
+            if (config.ImpressionListener != null)
+            {
+                ((AsynchronousImpressionListener)impressionListener).AddListener(config.ImpressionListener);
+            }
         }
 
         private void BuildMetricsLog()

--- a/NetSDK/Services/Client/Classes/SelfRefreshingClient.cs
+++ b/NetSDK/Services/Client/Classes/SelfRefreshingClient.cs
@@ -214,7 +214,10 @@ namespace Splitio.Services.Client.Classes
             treatmentLog = new SelfUpdatingTreatmentLog(treatmentSdkApiClient, TreatmentLogRefreshRate, impressionsCache);
             impressionListener = new AsynchronousImpressionListener();
             ((AsynchronousImpressionListener)impressionListener).AddListener(treatmentLog);
-            ((AsynchronousImpressionListener)impressionListener).AddListener(config.ImpressionListener);
+            if (config.ImpressionListener != null)
+            {
+                ((AsynchronousImpressionListener)impressionListener).AddListener(config.ImpressionListener);
+            }
         }
 
 

--- a/NetSDK/Version.cs
+++ b/NetSDK/Version.cs
@@ -3,7 +3,7 @@ namespace Splitio
 {
     public static class Version
     {
-        public static string SplitSdkVersion = "3.1.0";
+        public static string SplitSdkVersion = "3.1.1";
         public static string SplitSpecVersion = "1.0";
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 nuget:
   account_feed: true
 
-version: 3.1.0
+version: 3.1.1
 
 before_build:
  - nuget restore


### PR DESCRIPTION
Net sdk was adding a custom impression listener to list, even if not configured (null).
Solution: Avoid adding custom impression listener if not configured

to review: @dendril @patricioe 