### PR TITLE
Remove NLog dependency and manage logs with common.logging

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 CHANGES
 
+3.1.2
+- Changed logging approach by supporting Common.Logging integration. Client can configure its already existing logging system 
+by using Common.Logging adapter, to be used in Splitio SDK.
+
 3.1.1
 - Bug fix.
 

--- a/Detailed-README.md
+++ b/Detailed-README.md
@@ -257,4 +257,31 @@ The SDK polls Split servers for feature split and segment changes at regular per
 ###  Logging in the SDK 
 
 The .NET SDK uses Common.Logging for logging. It allows to configure different adapters such as log4net or NLog, and you can also write your own adapter by implementing ILoggerFactoryAdapter interface. More details [here](http://netcommon.sourceforge.net/docs/2.1.0/reference/html/ch01.html)
- 
+Splitio SDK doesn't log by default, you need to configure an adapter.
+
+This is an example on how to configure NLog and its adapter:
+
+```cs
+	var config = new LoggingConfiguration();
+	var fileTarget = new FileTarget();
+	config.AddTarget("file", fileTarget);
+	fileTarget.FileName = @"ANY FILE NAME";
+	fileTarget.ArchiveFileName = "ANY FILE NAME";
+	fileTarget.LineEnding = LineEndingMode.CRLF;
+	fileTarget.Layout = "${longdate} ${level: uppercase = true} ${logger} - ${message} - ${exception:format=tostring}";
+	fileTarget.ConcurrentWrites = true;
+	fileTarget.CreateDirs = true;
+	fileTarget.ArchiveNumbering = ArchiveNumberingMode.Date;
+	var rule = new LoggingRule("*", LogLevel.Debug, fileTarget);
+	config.LoggingRules.Add(rule);
+	LogManager.Configuration = config;     
+    
+    NameValueCollection properties = new NameValueCollection();
+    properties["configType"] = "INLINE";
+
+    Common.Logging.LogManager.Adapter = new Common.Logging.NLog.NLogLoggerFactoryAdapter(properties);
+	
+	...
+	
+    var factory = new SplitFactory("API_KEY", configurations);
+```	

--- a/Detailed-README.md
+++ b/Detailed-README.md
@@ -256,5 +256,5 @@ The SDK polls Split servers for feature split and segment changes at regular per
 
 ###  Logging in the SDK 
 
-The .NET SDK uses NLog for logging. If you do not configure it yourself, the SDK creates a file target and emits logs in a file named 'Logs\split-sdk.log'. You can learn more about configuring NLog [here](https://github.com/nlog/NLog/wiki/Configuration-API).
+The .NET SDK uses Common.Logging for logging. It allows to configure different adapters such as log4net or NLog, and you can also write your own adapter by implementing ILoggerFactoryAdapter interface. More details [here](http://netcommon.sourceforge.net/docs/2.1.0/reference/html/ch01.html)
  

--- a/Detailed-README.md
+++ b/Detailed-README.md
@@ -275,13 +275,13 @@ This is an example on how to configure NLog and its adapter:
 	var rule = new LoggingRule("*", LogLevel.Debug, fileTarget);
 	config.LoggingRules.Add(rule);
 	LogManager.Configuration = config;     
-    
-    NameValueCollection properties = new NameValueCollection();
-    properties["configType"] = "INLINE";
 
-    Common.Logging.LogManager.Adapter = new Common.Logging.NLog.NLogLoggerFactoryAdapter(properties);
-	
+	NameValueCollection properties = new NameValueCollection();
+	properties["configType"] = "INLINE";
+
+	Common.Logging.LogManager.Adapter = new Common.Logging.NLog.NLogLoggerFactoryAdapter(properties);
+
 	...
-	
-    var factory = new SplitFactory("API_KEY", configurations);
+
+	var factory = new SplitFactory("API_KEY", configurations);
 ```	

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,5 +1,8 @@
 NEWS
 
+3.1.2
+- New logging approach: Common.Logging
+
 3.1.1
 - No news for this update.
 

--- a/Net SDK Unit Tests/SplitioTests.csproj
+++ b/Net SDK Unit Tests/SplitioTests.csproj
@@ -54,10 +54,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.4.4.9\lib\net40\NLog.dll</HintPath>
-    </Reference>
     <Reference Include="StackExchange.Redis">
       <HintPath>..\packages\StackExchange.Redis.1.2.0\lib\net40\StackExchange.Redis.dll</HintPath>
     </Reference>

--- a/Net SDK Unit Tests/packages.config
+++ b/Net SDK Unit Tests/packages.config
@@ -5,6 +5,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
   <package id="Moq" version="4.0.10827" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
-  <package id="NLog" version="4.4.9" targetFramework="net40" />
   <package id="StackExchange.Redis" version="1.2.0" targetFramework="net40" />
 </packages>

--- a/NetSDK/CommonLibraries/SdkApiClient.cs
+++ b/NetSDK/CommonLibraries/SdkApiClient.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.Services.Metrics.Interfaces;
 using System;
 using System.Net;
@@ -11,7 +11,7 @@ namespace Splitio.CommonLibraries
     public class SdkApiClient : ISdkApiClient
     {
         private HttpClient httpClient;
-        private static readonly Logger Log = LogManager.GetLogger(typeof(SdkApiClient).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(SdkApiClient));
         protected IMetricsLog metricsLog;
 
         public SdkApiClient (HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null)

--- a/NetSDK/Services/Cache/Classes/InMemoryReadinessGatesCache.cs
+++ b/NetSDK/Services/Cache/Classes/InMemoryReadinessGatesCache.cs
@@ -2,14 +2,14 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Diagnostics;
-using NLog;
+using Common.Logging;
 using Splitio.Services.Cache.Interfaces;
 
 namespace Splitio.Services.Client.Classes
 {
     public class InMemoryReadinessGatesCache : IReadinessGatesCache
     {
-        private static readonly Logger Log = LogManager.GetLogger(typeof(InMemoryReadinessGatesCache).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(InMemoryReadinessGatesCache));
         private CountdownEvent splitsAreReady = new CountdownEvent(1);
         private Dictionary<String, CountdownEvent> segmentsAreReady = new Dictionary<String, CountdownEvent>();
 

--- a/NetSDK/Services/Cache/Classes/InMemorySegmentCache.cs
+++ b/NetSDK/Services/Cache/Classes/InMemorySegmentCache.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using System.Collections.Concurrent;
@@ -8,7 +8,7 @@ namespace Splitio.Services.Cache.Classes
 {
     public class InMemorySegmentCache : ISegmentCache
     {
-        private static readonly Logger Log = LogManager.GetLogger(typeof(InMemorySegmentCache).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(InMemorySegmentCache));
 
         private ConcurrentDictionary<string, Segment> segments;
 

--- a/NetSDK/Services/Cache/Classes/InMemorySplitCache.cs
+++ b/NetSDK/Services/Cache/Classes/InMemorySplitCache.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using System.Collections.Concurrent;
@@ -9,7 +9,7 @@ namespace Splitio.Services.Cache.Classes
 {
     public class InMemorySplitCache : ISplitCache
     {
-        private static readonly Logger Log = LogManager.GetLogger(typeof(InMemorySplitCache).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(InMemorySplitCache));
 
         private ConcurrentDictionary<string, ParsedSplit> splits;
         private long changeNumber;

--- a/NetSDK/Services/Cache/Classes/RedisAdapter.cs
+++ b/NetSDK/Services/Cache/Classes/RedisAdapter.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.Services.Cache.Interfaces;
 using StackExchange.Redis;
 using System;
@@ -10,7 +10,7 @@ namespace Splitio.Services.Cache.Classes
 {
     public class RedisAdapter : IRedisAdapter
     {
-        private static readonly Logger Log = LogManager.GetLogger(typeof(RedisAdapter).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(RedisAdapter));
 
         private ConnectionMultiplexer redis;
         private IDatabase database;

--- a/NetSDK/Services/Client/Classes/JSONFileClient.cs
+++ b/NetSDK/Services/Client/Classes/JSONFileClient.cs
@@ -1,6 +1,4 @@
-﻿using NLog;
-using NLog.Config;
-using NLog.Targets;
+﻿using Common.Logging;
 using Splitio.Domain;
 using Splitio.Services.Cache.Classes;
 using Splitio.Services.Cache.Interfaces;
@@ -18,7 +16,7 @@ namespace Splitio.Services.Client.Classes
 {
     public class JSONFileClient:SplitClient
     {
-        private static readonly Logger Log = LogManager.GetLogger(typeof(JSONFileClient).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(JSONFileClient));
         public JSONFileClient(string splitsFilePath, string segmentsFilePath, ISegmentCache segmentCacheInstance = null, ISplitCache splitCacheInstance = null, IImpressionListener treatmentLogInstance = null, bool isLabelsEnabled = true)
         {
             segmentCache = segmentCacheInstance ?? new InMemorySegmentCache(new ConcurrentDictionary<string, Segment>());

--- a/NetSDK/Services/Client/Classes/LocalhostClient.cs
+++ b/NetSDK/Services/Client/Classes/LocalhostClient.cs
@@ -1,6 +1,4 @@
-﻿using NLog;
-using NLog.Config;
-using NLog.Targets;
+﻿using Common.Logging;
 using Splitio.Domain;
 using Splitio.Services.Cache.Classes;
 using Splitio.Services.EngineEvaluator;
@@ -14,7 +12,7 @@ namespace Splitio.Services.Client.Classes
 {
     public class LocalhostClient : SplitClient
     {
-        private static readonly Logger Log = LogManager.GetLogger(typeof(LocalhostClient).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(LocalhostClient));
 
         private FileSystemWatcher watcher;
         private string fullPath;

--- a/NetSDK/Services/Client/Classes/RedisClient.cs
+++ b/NetSDK/Services/Client/Classes/RedisClient.cs
@@ -1,6 +1,4 @@
-﻿using NLog;
-using NLog.Config;
-using NLog.Targets;
+﻿using Common.Logging;
 using Splitio.CommonLibraries;
 using Splitio.Domain;
 using Splitio.Services.Cache.Classes;

--- a/NetSDK/Services/Client/Classes/SelfRefreshingClient.cs
+++ b/NetSDK/Services/Client/Classes/SelfRefreshingClient.cs
@@ -17,9 +17,7 @@ using System.Linq;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Parsing.Classes;
 using System.Net.Sockets;
-using NLog.Targets;
-using NLog.Config;
-using NLog;
+using Common.Logging;
 
 namespace Splitio.Services.Client.Classes
 {

--- a/NetSDK/Services/Client/Classes/SplitClient.cs
+++ b/NetSDK/Services/Client/Classes/SplitClient.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.CommonLibraries;
 using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
@@ -15,7 +15,7 @@ namespace Splitio.Services.Client.Classes
 {
     public abstract class SplitClient: ISplitClient
     {
-        protected static readonly Logger Log = LogManager.GetLogger(typeof(SplitClient).ToString());
+        protected static readonly ILog Log = LogManager.GetLogger(typeof(SplitClient));
         protected const string Control = "control";
         protected const string SdkGetTreatment = "sdk.getTreatment";
         protected const string LabelKilled = "killed";

--- a/NetSDK/Services/Client/Classes/SplitFactory.cs
+++ b/NetSDK/Services/Client/Classes/SplitFactory.cs
@@ -1,6 +1,4 @@
-﻿using NLog;
-using NLog.Config;
-using NLog.Targets;
+﻿using Common.Logging;
 using Splitio.Services.Client.Interfaces;
 using System;
 using System.Linq;
@@ -18,41 +16,8 @@ namespace Splitio.Services.Client.Classes
         {
             this.apiKey = apiKey;
             this.options = options;
-            InitializeLogger();
         }
 
-        private void InitializeLogger()
-        {
-            var fileTarget = new FileTarget();
-            fileTarget.Name = "splitio";
-            fileTarget.FileName = @".\Logs\splitio.log";
-            fileTarget.ArchiveFileName = @".\Logs\splitio.{#}.log";
-            fileTarget.LineEnding = LineEndingMode.CRLF;
-            fileTarget.Layout = "${longdate} ${level: uppercase = true} ${logger} - ${message} - ${exception:format=tostring}";
-            fileTarget.ConcurrentWrites = true;
-            fileTarget.CreateDirs = true;
-            fileTarget.ArchiveNumbering = ArchiveNumberingMode.DateAndSequence;
-            fileTarget.ArchiveAboveSize = 200000000;
-            fileTarget.ArchiveDateFormat = "yyyyMMdd";
-            fileTarget.MaxArchiveFiles = 30;
-            var rule = new LoggingRule("*", LogLevel.Debug, fileTarget);
-
-            if (LogManager.Configuration == null)
-            {
-                var config = new LoggingConfiguration();
-                config.AddTarget("splitio", fileTarget);
-                config.LoggingRules.Add(rule);
-                LogManager.Configuration = config;
-            }
-            else
-            {
-                if (LogManager.Configuration.ConfiguredNamedTargets.Where(x => x.Name == "splitio").FirstOrDefault() == null)
-                {
-                    LogManager.Configuration.AddTarget("splitio", fileTarget);
-                    LogManager.Configuration.LoggingRules.Add(rule);
-                }
-            }
-        }
 
         public ISplitClient Client()
         {

--- a/NetSDK/Services/Impressions/Classes/AsynchronousImpressionListener.cs
+++ b/NetSDK/Services/Impressions/Classes/AsynchronousImpressionListener.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Splitio.Services.Impressions.Interfaces;
 using Splitio.Domain;
 using System.Threading.Tasks;
-using NLog;
+using Common.Logging;
 using System.Diagnostics;
 
 
@@ -13,7 +13,7 @@ namespace Splitio.Services.Impressions.Classes
 {
     public class AsynchronousImpressionListener : IImpressionListener
     {
-        private static readonly Logger Logger = LogManager.GetLogger(typeof(AsynchronousImpressionListener).ToString());
+        private static readonly ILog Logger = LogManager.GetLogger(typeof(AsynchronousImpressionListener));
         private List<IImpressionListener> workers = new List<IImpressionListener>();
 
         public void AddListener(IImpressionListener worker)

--- a/NetSDK/Services/Impressions/Classes/SelfUpdatingTreatmentLog.cs
+++ b/NetSDK/Services/Impressions/Classes/SelfUpdatingTreatmentLog.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Newtonsoft.Json;
 using Splitio.CommonLibraries;
 using Splitio.Domain;
@@ -20,7 +20,7 @@ namespace Splitio.Services.Impressions.Classes
         private IImpressionsCache impressionsCache;
         private CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
-        private static readonly Logger Logger = LogManager.GetLogger(typeof(SelfUpdatingTreatmentLog).ToString());
+        private static readonly ILog Logger = LogManager.GetLogger(typeof(SelfUpdatingTreatmentLog));
 
         public SelfUpdatingTreatmentLog(ITreatmentSdkApiClient apiClient, int interval, IImpressionsCache impressionsCache, int maximumNumberOfKeysToCache = -1)
         {

--- a/NetSDK/Services/Impressions/Classes/TreatmentSdkApiClient.cs
+++ b/NetSDK/Services/Impressions/Classes/TreatmentSdkApiClient.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.CommonLibraries;
 using Splitio.Services.Impressions.Interfaces;
 using System;
@@ -10,7 +10,7 @@ namespace Splitio.Services.Impressions.Classes
     {
         private const string TestImpressionsUrlTemplate = "/api/testImpressions/bulk";
 
-        private static readonly Logger Log = LogManager.GetLogger(typeof(TreatmentSdkApiClient).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(TreatmentSdkApiClient));
 
         public TreatmentSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) : base(header, baseUrl, connectionTimeOut, readTimeout) { }
 

--- a/NetSDK/Services/Metrics/Classes/AsyncMetricsLog.cs
+++ b/NetSDK/Services/Metrics/Classes/AsyncMetricsLog.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Metrics.Interfaces;
 using System;
@@ -11,7 +11,7 @@ namespace Splitio.Services.Metrics.Classes
     {
         IMetricsLog worker;
 
-        private static readonly Logger Logger = LogManager.GetLogger(typeof(AsyncMetricsLog).ToString());
+        private static readonly ILog Logger = LogManager.GetLogger(typeof(AsyncMetricsLog));
 
         public AsyncMetricsLog(IMetricsSdkApiClient apiClient, IMetricsCache metricsCache, int maxCountCalls = -1, int maxTimeBetweenCalls = -1)
         {

--- a/NetSDK/Services/Metrics/Classes/InMemoryMetricsLog.cs
+++ b/NetSDK/Services/Metrics/Classes/InMemoryMetricsLog.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Newtonsoft.Json;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Metrics.Interfaces;
@@ -28,7 +28,7 @@ namespace Splitio.Services.Metrics.Classes
         private int gaugeCallCount = 0;
 
 
-        protected static readonly Logger Logger = LogManager.GetLogger(typeof(InMemoryMetricsLog).ToString());
+        protected static readonly ILog Logger = LogManager.GetLogger(typeof(InMemoryMetricsLog));
 
         public InMemoryMetricsLog(IMetricsSdkApiClient apiClient, IMetricsCache metricsCache, int maxCountCalls = 1000, int maxTimeBetweenCalls = 60)
         {

--- a/NetSDK/Services/Metrics/Classes/MetricsSdkApiClient.cs
+++ b/NetSDK/Services/Metrics/Classes/MetricsSdkApiClient.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.CommonLibraries;
 using Splitio.Services.Metrics.Interfaces;
 using System;
@@ -10,7 +10,7 @@ namespace Splitio.Services.Metrics.Classes
     {
         private const string MetricsUrlTemplate = "/api/metrics/{endpoint}";
 
-        private static readonly Logger Log = LogManager.GetLogger(typeof(MetricsSdkApiClient).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(MetricsSdkApiClient));
 
         public MetricsSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) : base(header, baseUrl, connectionTimeOut, readTimeout) { }
 

--- a/NetSDK/Services/Parsing/Classes/SplitParser.cs
+++ b/NetSDK/Services/Parsing/Classes/SplitParser.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.SegmentFetcher.Interfaces;
@@ -10,7 +10,7 @@ namespace Splitio.Services.Parsing
 {
     public abstract class SplitParser
     {
-        private static readonly Logger Log = LogManager.GetLogger(typeof(SplitParser).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(SplitParser));
         protected ISegmentCache segmentsCache;
 
         public ParsedSplit Parse(Split split)

--- a/NetSDK/Services/SegmentFetcher/Classes/SegmentChangeFetcher.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SegmentChangeFetcher.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.Domain;
 using Splitio.Services.SegmentFetcher.Interfaces;
 using System;
@@ -8,7 +8,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
     public abstract class SegmentChangeFetcher: ISegmentChangeFetcher
     {
         private SegmentChange segmentChange;
-        private static readonly Logger Log = LogManager.GetLogger(typeof(SegmentChangeFetcher).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(SegmentChangeFetcher));
 
         protected abstract SegmentChange FetchFromBackend(string name, long since);
 

--- a/NetSDK/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Net;
 using Splitio.Services.SplitFetcher.Interfaces;
-using NLog;
+using Common.Logging;
 using Splitio.Services.Metrics.Interfaces;
 using System.Diagnostics;
 
@@ -16,7 +16,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
         private const string SegmentFetcherStatus = "segmentChangeFetcher.status.{0}";
         private const string SegmentFetcherException = "segmentChangeFetcher.exception";
 
-        private static readonly Logger Log = LogManager.GetLogger(typeof(SegmentSdkApiClient).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(SegmentSdkApiClient));
 
         public SegmentSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null) : base(header, baseUrl, connectionTimeOut, readTimeout, metricsLog) { }
 

--- a/NetSDK/Services/SegmentFetcher/Classes/SegmentTaskWorker.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SegmentTaskWorker.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,7 +7,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
 {
     public class SegmentTaskWorker
     {
-        private static readonly Logger Log = LogManager.GetLogger(typeof(SegmentTaskWorker).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(SegmentTaskWorker));
 
         int numberOfParallelTasks;
         int counter;

--- a/NetSDK/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Client.Classes;
 using Splitio.Services.SegmentFetcher.Interfaces;
@@ -9,7 +9,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
 {
     public class SelfRefreshingSegment
     {
-        private static readonly Logger Log = LogManager.GetLogger(typeof(SelfRefreshingSegment).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(SelfRefreshingSegment));
 
         public string name;
         private IReadinessGatesCache gates;

--- a/NetSDK/Services/SegmentFetcher/Classes/SelfRefreshingSegmentFetcher.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SelfRefreshingSegmentFetcher.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.CommonLibraries;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Client.Classes;
@@ -12,7 +12,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
 {
     public class SelfRefreshingSegmentFetcher : SegmentFetcher
     {
-        private static readonly Logger Log = LogManager.GetLogger(typeof(SelfRefreshingSegmentFetcher).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(SelfRefreshingSegmentFetcher));
         
         private readonly ISegmentChangeFetcher segmentChangeFetcher;
         private ConcurrentDictionary<string, SelfRefreshingSegment> segments;

--- a/NetSDK/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
+++ b/NetSDK/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.CommonLibraries;
 using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
@@ -16,7 +16,7 @@ namespace Splitio.Services.SplitFetcher.Classes
     public class SelfRefreshingSplitFetcher 
     {
         protected ISplitCache splitCache;
-        private static readonly Logger Log = LogManager.GetLogger(typeof(SelfRefreshingSplitFetcher).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(SelfRefreshingSplitFetcher));
         private readonly ISplitChangeFetcher splitChangeFetcher;
         private readonly SplitParser splitParser;
         private int interval;

--- a/NetSDK/Services/SplitFetcher/Classes/SplitChangeFetcher.cs
+++ b/NetSDK/Services/SplitFetcher/Classes/SplitChangeFetcher.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+﻿using Common.Logging;
 using Splitio.Domain;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System;
@@ -8,7 +8,7 @@ namespace Splitio.Services.SplitFetcher.Classes
     public abstract class SplitChangeFetcher : ISplitChangeFetcher
     {
         private SplitChangesResult splitChanges;
-        private static readonly Logger Log = LogManager.GetLogger(typeof(SplitChangeFetcher).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(SplitChangeFetcher));
 
         protected abstract SplitChangesResult FetchFromBackend(long since);
 

--- a/NetSDK/Services/SplitFetcher/Classes/SplitSdkApiClient.cs
+++ b/NetSDK/Services/SplitFetcher/Classes/SplitSdkApiClient.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Net;
 using Splitio.Services.SplitFetcher.Interfaces;
-using NLog;
+using Common.Logging;
 using Splitio.Services.Metrics.Interfaces;
 using System.Diagnostics;
 
@@ -16,7 +16,7 @@ namespace Splitio.Services.SplitFetcher.Classes
         private const string SplitFetcherStatus = "splitChangeFetcher.status.{0}";
         private const string SplitFetcherException = "splitChangeFetcher.exception";
 
-        private static readonly Logger Log = LogManager.GetLogger(typeof(SplitSdkApiClient).ToString());
+        private static readonly ILog Log = LogManager.GetLogger(typeof(SplitSdkApiClient));
 
         public SplitSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null) : base(header, baseUrl, connectionTimeOut, readTimeout, metricsLog) { }
 

--- a/NetSDK/Splitio.csproj
+++ b/NetSDK/Splitio.csproj
@@ -32,6 +32,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Common.Logging">
+      <HintPath>..\packages\Common.Logging.3.4.0-Beta2\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\packages\Common.Logging.Core.3.4.0-Beta2\lib\net40\Common.Logging.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
@@ -50,9 +56,6 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="NLog">
-      <HintPath>..\packages\NLog.4.4.9\lib\net40\NLog.dll</HintPath>
     </Reference>
     <Reference Include="StackExchange.Redis, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/NetSDK/Version.cs
+++ b/NetSDK/Version.cs
@@ -3,7 +3,7 @@ namespace Splitio
 {
     public static class Version
     {
-        public static string SplitSdkVersion = "3.1.2-rc188";
+        public static string SplitSdkVersion = "3.1.2-rc205";
         public static string SplitSpecVersion = "1.0";
     }
 }

--- a/NetSDK/packages.config
+++ b/NetSDK/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Common.Logging" version="3.4.0-Beta2" targetFramework="net40" />
+  <package id="Common.Logging.Core" version="3.4.0-Beta2" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net40" />
   <package id="murmurhash" version="1.0.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
-  <package id="NLog" version="4.4.9" targetFramework="net40" />
   <package id="StackExchange.Redis" version="1.2.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Replaced NLog with Common.Logging to allow the client to configure its own logging system (NLog/Log4net)

@patricioe @dendril  to review