### PR TITLE
Use dynamic version number

### DIFF
--- a/NetSDK/Properties/AssemblyInfo.cs
+++ b/NetSDK/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build Number
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0")]
-[assembly: AssemblyFileVersion("1.0.*")]
-[assembly: AssemblyInformationalVersion("1.0 RC1")]
+[assembly: AssemblyVersion("1.0.0.1")] // Replaced by appveyor  
+[assembly: AssemblyFileVersion("1.0.0-1")] // Replaced by appveyor  
+[assembly: AssemblyInformationalVersion("1.0 RC1")] // Replaced by appveyor  

--- a/NetSDK/Version.cs
+++ b/NetSDK/Version.cs
@@ -1,9 +1,12 @@
 ﻿
+using System.Diagnostics;
+using System.Reflection;
+
 namespace Splitio
 {
     public static class Version
     {
-        public static string SplitSdkVersion = "3.3.2-beta1";
+        public static string SplitSdkVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
         public static string SplitSpecVersion = "1.0";
     }
 }

--- a/Splitio.Redis/Properties/AssemblyInfo.cs
+++ b/Splitio.Redis/Properties/AssemblyInfo.cs
@@ -32,5 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")] // Replaced by appveyor  
+[assembly: AssemblyFileVersion("1.0.0.0")] // Replaced by appveyor  
+[assembly: AssemblyInformationalVersion("1.0.0.0")] // Replaced by appveyor  

--- a/Splitio.TestSupport/Properties/AssemblyInfo.cs
+++ b/Splitio.TestSupport/Properties/AssemblyInfo.cs
@@ -32,5 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")] // Replaced by appveyor  
+[assembly: AssemblyFileVersion("1.0.0.0")] // Replaced by appveyor  
+[assembly: AssemblyInformationalVersion("1.0.0.0")] // Replaced by appveyor  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,17 @@ nuget:
 
 version: 3.3.2-rc{build}
 
+assembly_info:
+  patch: true
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
+  
 configuration: Release
 
 before_build:
  - nuget restore
- - cmd: set BUILD_VERSION=%APPVEYOR_BUILD_NUMBER%
+ - cmd: set BUILD_VERSION=%appveyor_build_version%
  
 after_build:
  - nuget pack NetSDK\Splitio.csproj -Version %appveyor_build_version%


### PR DESCRIPTION
# Background
There are multiple places where the version number is being set so this change consists on using the appveyor build number for the Nuget package version number and for the assembly informational version, which is the one used in the SDK 