### PR TITLE
Fix date rules issues

### DIFF
--- a/Net SDK Unit Tests/Unit Tests/CommonLibraries/TypeConverterUnitTests.cs
+++ b/Net SDK Unit Tests/Unit Tests/CommonLibraries/TypeConverterUnitTests.cs
@@ -89,13 +89,13 @@ namespace Splitio_Tests.Unit_Tests.CommonLibraries
 
             //Assert
             Assert.IsNotNull(result);
-            Assert.AreEqual(2016, result?.Year);
-            Assert.AreEqual(4, result?.Month);
-            Assert.AreEqual(21, result?.Day);
-            Assert.AreEqual(0, result?.Hour);
-            Assert.AreEqual(0, result?.Minute);
-            Assert.AreEqual(0, result?.Second);
-            Assert.AreEqual(0, result?.Millisecond);
+            Assert.AreEqual(2016, result.Value.Year);
+            Assert.AreEqual(4, result.Value.Month);
+            Assert.AreEqual(21, result.Value.Day);
+            Assert.AreEqual(0, result.Value.Hour);
+            Assert.AreEqual(0, result.Value.Minute);
+            Assert.AreEqual(0, result.Value.Second);
+            Assert.AreEqual(0, result.Value.Millisecond);
         }
     }
 }

--- a/Net SDK Unit Tests/Unit Tests/CommonLibraries/TypeConverterUnitTests.cs
+++ b/Net SDK Unit Tests/Unit Tests/CommonLibraries/TypeConverterUnitTests.cs
@@ -77,5 +77,25 @@ namespace Splitio_Tests.Unit_Tests.CommonLibraries
             Assert.AreEqual(0, result.Second);
             Assert.AreEqual(0, result.Millisecond);
         }
+
+        [TestMethod]
+        public void ConvertStringToDateTimeWorks()
+        {
+            //Arrange
+            string value = "2016-04-21";
+
+            //Act
+            var result = value.ToDateTime();
+
+            //Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(2016, result?.Year);
+            Assert.AreEqual(4, result?.Month);
+            Assert.AreEqual(21, result?.Day);
+            Assert.AreEqual(0, result?.Hour);
+            Assert.AreEqual(0, result?.Minute);
+            Assert.AreEqual(0, result?.Second);
+            Assert.AreEqual(0, result?.Millisecond);
+        }
     }
 }

--- a/NetSDK/CommonLibraries/TypeConverter.cs
+++ b/NetSDK/CommonLibraries/TypeConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Splitio.CommonLibraries
 {
@@ -21,7 +22,7 @@ namespace Splitio.CommonLibraries
             }
 
             DateTime datetime;
-            if (DateTime.TryParse(timestampString, out datetime))
+            if (DateTime.TryParse(timestampString, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out datetime))
             {
                 return datetime;
             }

--- a/NetSDK/CommonLibraries/TypeConverter.cs
+++ b/NetSDK/CommonLibraries/TypeConverter.cs
@@ -19,6 +19,13 @@ namespace Splitio.CommonLibraries
             {
                 return timestamp.ToDateTime();
             }
+
+            DateTime datetime;
+            if (DateTime.TryParse(timestampString, out datetime))
+            {
+                return datetime;
+            }
+
             return null;
         }
 

--- a/NetSDK/Services/Parsing/Classes/BetweenMatcher.cs
+++ b/NetSDK/Services/Parsing/Classes/BetweenMatcher.cs
@@ -26,7 +26,7 @@ namespace Splitio.Services.Parsing
             var startDate = start.ToDateTime();
             var endDate = end.ToDateTime();
             key = key.Truncate(TimeSpan.FromMinutes(1)); // Truncate to whole minute
-            return (startDate <= key) && (key <= endDate);
+            return (startDate.ToUniversalTime() <= key.ToUniversalTime()) && (key.ToUniversalTime() <= endDate.ToUniversalTime());
         }
     }
 }

--- a/NetSDK/Services/Parsing/Classes/EqualToMatcher.cs
+++ b/NetSDK/Services/Parsing/Classes/EqualToMatcher.cs
@@ -16,6 +16,11 @@ namespace Splitio.Services.Parsing
 
         public override bool Match(long key, Dictionary<string, object> attributes = null, ISplitClient splitClient = null)
         {
+            if (dataType == DataTypeEnum.DATETIME)
+            {
+                return Match(value.ToDateTime(), attributes, splitClient);
+            }
+
             return value == key;
         }
 

--- a/NetSDK/Services/Parsing/Classes/EqualToMatcher.cs
+++ b/NetSDK/Services/Parsing/Classes/EqualToMatcher.cs
@@ -28,7 +28,7 @@ namespace Splitio.Services.Parsing
         {
             var date = value.ToDateTime();
 
-            return date.Date == key.Date; // Compare just date part
+            return date.ToUniversalTime().Date == key.ToUniversalTime().Date; // Compare just date part
         }
 
         public override bool Match(bool key, Dictionary<string, object> attributes = null, ISplitClient splitClient = null)

--- a/NetSDK/Services/Parsing/Classes/EqualToMatcher.cs
+++ b/NetSDK/Services/Parsing/Classes/EqualToMatcher.cs
@@ -18,7 +18,7 @@ namespace Splitio.Services.Parsing
         {
             if (dataType == DataTypeEnum.DATETIME)
             {
-                return Match(value.ToDateTime(), attributes, splitClient);
+                return Match(key.ToDateTime(), attributes, splitClient);
             }
 
             return value == key;

--- a/NetSDK/Services/Parsing/Classes/GreaterOrEqualToMatcher.cs
+++ b/NetSDK/Services/Parsing/Classes/GreaterOrEqualToMatcher.cs
@@ -23,7 +23,7 @@ namespace Splitio.Services.Parsing
         {
             var date = value.ToDateTime();
             key = key.Truncate(TimeSpan.FromMinutes(1)); // Truncate to whole minute
-            return key >= date;
+            return key.ToUniversalTime() >= date.ToUniversalTime();
         }
 
         public override bool Match(bool key, Dictionary<string, object> attributes = null, ISplitClient splitClient = null)

--- a/NetSDK/Services/Parsing/Classes/LessOrEqualToMatcher.cs
+++ b/NetSDK/Services/Parsing/Classes/LessOrEqualToMatcher.cs
@@ -23,7 +23,7 @@ namespace Splitio.Services.Parsing
         {
             var date = value.ToDateTime();
             key = key.Truncate(TimeSpan.FromMinutes(1)); // Truncate to whole minute
-            return key <= date;
+            return key.ToUniversalTime() <= date.ToUniversalTime();
         }
 
         public override bool Match(bool key, Dictionary<string, object> attributes = null, ISplitClient splitClient = null)


### PR DESCRIPTION
# Background
After some changes made by @SenhorCastor in the Qos app related to how dates are being sent to the testing app, some tests started failing. 
The main issue was that the data type of the rule was inferred by looking at the value being sent to the app, instead of checking the data type of the rule. Because of that, when an epoch date was sent, the SDK assumed that an integer comparison needed to be made so it never matched (because the long value wasn't the same due to differences in the hour+minutes+seconds+milliseconds part)

# Changes made
- Adjust `EqualToMatcher` and `TypeConverter` classes
- Adjust some unit tests
- Use UTC whenever we are comparing dates