### PR TITLE
Fix segments timeouts

### DIFF
--- a/Net SDK Unit Tests/Integration Tests/SdkApiClientTests.cs
+++ b/Net SDK Unit Tests/Integration Tests/SdkApiClientTests.cs
@@ -10,14 +10,13 @@ namespace Splitio_Tests.Integration_Tests
     {
         [TestMethod]
         [Ignore]
-        public void ExecuteGetSuccessful()
+        public async void ExecuteGetSuccessful()
         {
             //Arrange
             var baseUrl = "http://demo7064886.mockable.io";
             var httpHeader = new HTTPHeader()
             {
                 authorizationApiKey = "ABCD",
-                encoding = "gzip",
                 splitSDKMachineIP = "1.0.0.0",
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "1",
@@ -26,7 +25,7 @@ namespace Splitio_Tests.Integration_Tests
             var SdkApiClient = new SdkApiClient(httpHeader, baseUrl, 10000, 10000);
 
             //Act
-            var result = SdkApiClient.ExecuteGet("/messages?item=msg1");
+            var result = await SdkApiClient.ExecuteGet("/messages?item=msg1");
 
             //Assert
             Assert.AreEqual(result.statusCode, HttpStatusCode.OK);
@@ -36,13 +35,12 @@ namespace Splitio_Tests.Integration_Tests
 
         [TestMethod]
         [Ignore]
-        public void ExecuteGetShouldReturnErrorNotAuthorized()
+        public async void ExecuteGetShouldReturnErrorNotAuthorized()
         {
             //Arrange
             var baseUrl = "http://demo7064886.mockable.io";
             var httpHeader = new HTTPHeader()
             {
-                encoding = "gzip",
                 splitSDKMachineIP = "1.0.0.0",
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "1",
@@ -51,7 +49,7 @@ namespace Splitio_Tests.Integration_Tests
             var SdkApiClient = new SdkApiClient(httpHeader, baseUrl, 10000, 10000);
 
             //Act
-            var result = SdkApiClient.ExecuteGet("/messages?item=msg2");
+            var result = await SdkApiClient.ExecuteGet("/messages?item=msg2");
 
             //Assert
             Assert.AreEqual(result.statusCode, HttpStatusCode.Unauthorized);
@@ -59,14 +57,13 @@ namespace Splitio_Tests.Integration_Tests
 
         [TestMethod]
         [Ignore]
-        public void ExecuteGetShouldReturnNotFoundOnInvalidRequest()
+        public async void ExecuteGetShouldReturnNotFoundOnInvalidRequest()
         {
             //Arrange
             var baseUrl = "http://demo706abcd.mockable.io";
             var httpHeader = new HTTPHeader()
             {
                 authorizationApiKey = "ABCD",
-                encoding = "gzip",
                 splitSDKMachineIP = "1.0.0.0",
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "1",
@@ -75,14 +72,14 @@ namespace Splitio_Tests.Integration_Tests
             var SdkApiClient = new SdkApiClient(httpHeader, baseUrl, 10000, 10000);
 
             //Act
-            var result = SdkApiClient.ExecuteGet("/messages?item=msg2");
+            var result = await SdkApiClient.ExecuteGet("/messages?item=msg2");
 
             //Assert
             Assert.AreEqual(result.statusCode, HttpStatusCode.NotFound);
         }
 
         [TestMethod]
-        public void ExecuteGetShouldReturnEmptyResponseOnInvalidURL()
+        public async void ExecuteGetShouldReturnEmptyResponseOnInvalidURL()
         {
             //Arrange
 
@@ -90,7 +87,6 @@ namespace Splitio_Tests.Integration_Tests
             var httpHeader = new HTTPHeader()
             {
                 authorizationApiKey = "ABCD",
-                encoding = "gzip",
                 splitSDKMachineIP = "1.0.0.0",
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "1",
@@ -99,7 +95,7 @@ namespace Splitio_Tests.Integration_Tests
             var SdkApiClient = new SdkApiClient(httpHeader, baseUrl, 10000, 10000);
 
             //Act
-            var result = SdkApiClient.ExecuteGet("/messages?item=msg2");
+            var result = await SdkApiClient.ExecuteGet("/messages?item=msg2");
 
             //Assert
             Assert.IsNotNull(result);

--- a/Net SDK Unit Tests/Integration Tests/SelfRefreshingSegmentFetcherTests.cs
+++ b/Net SDK Unit Tests/Integration Tests/SelfRefreshingSegmentFetcherTests.cs
@@ -42,7 +42,6 @@ namespace Splitio_Tests.Integration_Tests
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "net-0.0.0",
                 splitSDKSpecVersion = "1.2",
-                encoding = "gzip"
             };
             var sdkApiClient = new SegmentSdkApiClient(httpHeader, baseUrl, 10000, 10000);
             var apiSegmentChangeFetcher = new ApiSegmentChangeFetcher(sdkApiClient);

--- a/Net SDK Unit Tests/Integration Tests/SelfRefreshingSplitFetcherTests.cs
+++ b/Net SDK Unit Tests/Integration Tests/SelfRefreshingSplitFetcherTests.cs
@@ -82,7 +82,6 @@ namespace Splitio_Tests.Integration_Tests
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "net-0.0.0",
                 splitSDKSpecVersion = "1.2",
-                encoding = "gzip"
             };
             var sdkApiClient = new SplitSdkApiClient(httpHeader, baseUrl, 10000, 10000);
             var apiSplitChangeFetcher = new ApiSplitChangeFetcher(sdkApiClient);
@@ -121,7 +120,6 @@ namespace Splitio_Tests.Integration_Tests
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "net-0.0.0",
                 splitSDKSpecVersion = "1.2",
-                encoding = "gzip"
             };
             var sdkApiClient = new SplitSdkApiClient(httpHeader, baseUrl, 10000, 10000);
             var apiSplitChangeFetcher = new ApiSplitChangeFetcher(sdkApiClient);

--- a/Net SDK Unit Tests/Integration Tests/SplitSdkApiClientTests.cs
+++ b/Net SDK Unit Tests/Integration Tests/SplitSdkApiClientTests.cs
@@ -11,7 +11,7 @@ namespace Splitio_Tests.Integration_Tests
     {
         [TestMethod]
         [Ignore]
-        public void ExecuteFetchSplitChangesSuccessful()
+        public async void ExecuteFetchSplitChangesSuccessful()
         {
             //Arrange
             var baseUrl = "http://sdk-aws-staging.split.io/api/";
@@ -22,12 +22,11 @@ namespace Splitio_Tests.Integration_Tests
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "net-0.0.0",
                 splitSDKSpecVersion = "1.2",
-                encoding = "gzip"
             };
             var SplitSdkApiClient = new SplitSdkApiClient(httpHeader, baseUrl, 10000, 10000);
 
             //Act
-            var result = SplitSdkApiClient.FetchSplitChanges(-1);
+            var result = await SplitSdkApiClient.FetchSplitChanges(-1);
   
             //Assert
             Assert.IsTrue(result.Contains("splits"));
@@ -36,13 +35,12 @@ namespace Splitio_Tests.Integration_Tests
 
 
         [TestMethod]
-        public void ExecuteGetShouldReturnEmptyIfNotAuthorized()
+        public async void ExecuteGetShouldReturnEmptyIfNotAuthorized()
         {
             //Arrange
             var baseUrl = "https://sdk.aws.staging.split.io/api";
             var httpHeader = new HTTPHeader()
             {
-                encoding = "gzip",
                 splitSDKMachineIP = "1.0.0.0",
                 splitSDKMachineName = "localhost",
                 splitSDKVersion = "net-0.0.0",
@@ -51,7 +49,7 @@ namespace Splitio_Tests.Integration_Tests
             var SplitSdkApiClient = new SplitSdkApiClient(httpHeader, baseUrl, 10000, 10000);
 
             //Act
-            var result = SplitSdkApiClient.FetchSplitChanges(-1);
+            var result = await SplitSdkApiClient.FetchSplitChanges(-1);
 
             //Assert
             Assert.IsTrue(result == String.Empty);

--- a/Net SDK Unit Tests/SplitioTests.csproj
+++ b/Net SDK Unit Tests/SplitioTests.csproj
@@ -19,6 +19,8 @@
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -244,12 +246,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Net SDK Unit Tests/Unit Tests/SegmentFetcher/ApiSegmentChangeFetcherUnitTests.cs
+++ b/Net SDK Unit Tests/Unit Tests/SegmentFetcher/ApiSegmentChangeFetcherUnitTests.cs
@@ -3,6 +3,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Splitio.Services.SegmentFetcher.Classes;
 using Moq;
 using Splitio.Services.SplitFetcher.Interfaces;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Splitio_Tests.Unit_Tests.SegmentFetcher
 {
@@ -10,13 +12,13 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
     public class ApiSegmentChangeFetcherUnitTests
     {
         [TestMethod]
-        public void FetchSegmentChangesSuccessfull()
+        public async void FetchSegmentChangesSuccessfull()
         {
             //Arrange
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
-            .Setup(x=>x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>()))
-            .Returns(@"{
+            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .Returns(TaskEx.FromResult(@"{
                           'name': 'payed',
                           'added': [
                             'abcdz',
@@ -26,11 +28,11 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
                           'removed': [],
                           'since': -1,
                           'till': 1470947453877
-                        }");
+                        }"));
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
             
             //Act
-            var result = apiFetcher.Fetch("payed", -1);
+            var result = await apiFetcher.Fetch("payed", -1);
 
             //Assert
             Assert.IsNotNull(result);
@@ -42,16 +44,16 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
         }
 
         [TestMethod]
-        public void FetchSegmentChangesWithExcepionSouldReturnNull()
+        public async void FetchSegmentChangesWithExcepionSouldReturnNull()
         {
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>()))
+            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
            
             //Act
-            var result = apiFetcher.Fetch("payed", -1);
+            var result = await apiFetcher.Fetch("payed", -1);
 
             //Assert
             Assert.IsNull(result);

--- a/Net SDK Unit Tests/Unit Tests/SegmentFetcher/SelfRefreshingSegmentFetcherUnitTests.cs
+++ b/Net SDK Unit Tests/Unit Tests/SegmentFetcher/SelfRefreshingSegmentFetcherUnitTests.cs
@@ -7,6 +7,7 @@ using Splitio.Domain;
 using Moq;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Splitio_Tests.Unit_Tests.SegmentFetcher
 {
@@ -20,8 +21,8 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var gates = new InMemoryReadinessGatesCache();
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>()))
-            .Returns(@"{
+            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .Returns(TaskEx.FromResult(@"{
                           'name': 'payed',
                           'added': [
                             'abcdz',
@@ -31,7 +32,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
                           'removed': [],
                           'since': -1,
                           'till': 10001
-                        }");
+                        }"));
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
             var segments = new ConcurrentDictionary<string, Segment>();
             var cache = new InMemorySegmentCache(segments);
@@ -53,8 +54,8 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var gates = new InMemoryReadinessGatesCache();
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>()))
-            .Returns(@"{
+            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .Returns(TaskEx.FromResult(@"{
                           'name': 'payed',
                           'added': [
                             'abcdz',
@@ -64,7 +65,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
                           'removed': [],
                           'since': -1,
                           'till': 10001
-                        }");
+                        }"));
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
             var segments = new ConcurrentDictionary<string, Segment>();
             var cache = new InMemorySegmentCache(segments);

--- a/Net SDK Unit Tests/Unit Tests/SegmentFetcher/SelfRefreshingSegmentUnitTests.cs
+++ b/Net SDK Unit Tests/Unit Tests/SegmentFetcher/SelfRefreshingSegmentUnitTests.cs
@@ -7,6 +7,8 @@ using Splitio.Services.Client.Classes;
 using Splitio.Services.Cache.Classes;
 using System.Collections.Concurrent;
 using Splitio.Domain;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Splitio_Tests.Unit_Tests.SegmentFetcher
 {
@@ -20,7 +22,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var gates = new InMemoryReadinessGatesCache();
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>()))
+            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
             .Throws(new Exception());
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
             var segments  = new ConcurrentDictionary<string, Segment>();
@@ -41,8 +43,8 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var gates = new InMemoryReadinessGatesCache();
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>()))
-            .Returns(@"{
+            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .Returns(TaskEx.FromResult(@"{
                           'name': 'payed',
                           'added': [
                             'abcdz',
@@ -52,7 +54,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
                           'removed': [],
                           'since': -1,
                           'till': -1
-                        }");
+                        }"));
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
             var segments = new ConcurrentDictionary<string, Segment>();
             var cache = new InMemorySegmentCache(segments);
@@ -72,8 +74,8 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
             var gates = new InMemoryReadinessGatesCache();
             var apiClient = new Mock<ISegmentSdkApiClient>();
             apiClient
-            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>()))
-            .Returns(@"{
+            .Setup(x => x.FetchSegmentChanges(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .Returns(TaskEx.FromResult(@"{
                           'name': 'payed',
                           'added': [
                             'abcdz',
@@ -83,7 +85,7 @@ namespace Splitio_Tests.Unit_Tests.SegmentFetcher
                           'removed': [],
                           'since': -1,
                           'till': 10001
-                        }");
+                        }"));
             var apiFetcher = new ApiSegmentChangeFetcher(apiClient.Object);
             var segments = new ConcurrentDictionary<string, Segment>();
             var cache = new InMemorySegmentCache(segments);

--- a/Net SDK Unit Tests/Unit Tests/SplitFetcher/ApiSplitChangeFetcherTests.cs
+++ b/Net SDK Unit Tests/Unit Tests/SplitFetcher/ApiSplitChangeFetcherTests.cs
@@ -5,6 +5,7 @@ using Splitio.Services.SplitFetcher.Interfaces;
 using Splitio.Services.SplitFetcher.Classes;
 using System.Linq;
 using Splitio.Domain;
+using System.Threading.Tasks;
 
 namespace Splitio_Tests.Unit_Tests
 {
@@ -19,7 +20,7 @@ namespace Splitio_Tests.Unit_Tests
             Mock<ISplitSdkApiClient> apiMock = new Mock<ISplitSdkApiClient>();
             apiMock
                 .Setup(x => x.FetchSplitChanges(-1))
-                .Returns("{\"splits\": [ { \"trafficType\": \"user\", \"name\": \"Reset_Seed_UI\", \"seed\": 1552577712, \"status\": \"ACTIVE\", \"defaultTreatment\": \"off\", \"changeNumber\": 1469827821322, \"conditions\": [ { \"matcherGroup\": { \"combiner\": \"AND\", \"matchers\": [ { \"keySelector\": { \"trafficType\": \"user\", \"attribute\": null }, \"matcherType\": \"ALL_KEYS\", \"negate\": false, \"userDefinedSegmentMatcherData\": null, \"whitelistMatcherData\": null, \"unaryNumericMatcherData\": null, \"betweenMatcherData\": null } ] }, \"partitions\": [ { \"treatment\": \"on\", \"size\": 100 }, { \"treatment\": \"off\", \"size\": 0, \"addedField\": \"test\"  } ] } ] } ], \"since\": 1469817846929, \"till\": 1469827821322 }\r\n");
+                .Returns(TaskEx.FromResult("{\"splits\": [ { \"trafficType\": \"user\", \"name\": \"Reset_Seed_UI\", \"seed\": 1552577712, \"status\": \"ACTIVE\", \"defaultTreatment\": \"off\", \"changeNumber\": 1469827821322, \"conditions\": [ { \"matcherGroup\": { \"combiner\": \"AND\", \"matchers\": [ { \"keySelector\": { \"trafficType\": \"user\", \"attribute\": null }, \"matcherType\": \"ALL_KEYS\", \"negate\": false, \"userDefinedSegmentMatcherData\": null, \"whitelistMatcherData\": null, \"unaryNumericMatcherData\": null, \"betweenMatcherData\": null } ] }, \"partitions\": [ { \"treatment\": \"on\", \"size\": 100 }, { \"treatment\": \"off\", \"size\": 0, \"addedField\": \"test\"  } ] } ] } ], \"since\": 1469817846929, \"till\": 1469827821322 }\r\n"));
 
             ApiSplitChangeFetcher apiSplitChangeFetcher = new ApiSplitChangeFetcher(apiMock.Object);
 
@@ -38,7 +39,7 @@ namespace Splitio_Tests.Unit_Tests
             var apiClient = new Mock<ISplitSdkApiClient>();
             apiClient
             .Setup(x => x.FetchSplitChanges(It.IsAny<long>()))
-            .Returns(@"{
+            .Returns(TaskEx.FromResult(@"{
                           'splits': [
                             {
                               'trafficTypeName': 'user',
@@ -83,7 +84,7 @@ namespace Splitio_Tests.Unit_Tests
                           ],
                           'since': -1,
                           'till': 1470855828956
-                        }");
+                        }"));
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
@@ -110,7 +111,7 @@ namespace Splitio_Tests.Unit_Tests
             var apiClient = new Mock<ISplitSdkApiClient>();
             apiClient
             .Setup(x => x.FetchSplitChanges(It.IsAny<long>()))
-            .Returns(@"{
+            .Returns(TaskEx.FromResult(@"{
                           'splits': [
                             {
                               'trafficTypeName': 'user',
@@ -156,7 +157,7 @@ namespace Splitio_Tests.Unit_Tests
                           ],
                           'since': -1,
                           'till': 1470855828956
-                        }");
+                        }"));
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
@@ -175,7 +176,7 @@ namespace Splitio_Tests.Unit_Tests
             var apiClient = new Mock<ISplitSdkApiClient>();
             apiClient
             .Setup(x => x.FetchSplitChanges(It.IsAny<long>()))
-            .Returns(@"{
+            .Returns(TaskEx.FromResult(@"{
                           'splits': [
                             {
                               'trafficTypeName': 'user',
@@ -221,7 +222,7 @@ namespace Splitio_Tests.Unit_Tests
                           ],
                           'since': -1,
                           'till': 1470855828956
-                        }");
+                        }"));
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act

--- a/Net SDK Unit Tests/Unit Tests/SplitFetcher/ApiSplitChangeFetcherTests.cs
+++ b/Net SDK Unit Tests/Unit Tests/SplitFetcher/ApiSplitChangeFetcherTests.cs
@@ -14,7 +14,7 @@ namespace Splitio_Tests.Unit_Tests
     {
         [TestMethod]
         [Description("Test a Json that changes its structure and is deserialized without exception. Contains: a field renamed, a field removed and a field added.")]
-        public void ExecuteJsonDeserializeSuccessfulWithChangeInJsonFormat()
+        public async void ExecuteJsonDeserializeSuccessfulWithChangeInJsonFormat()
         {
             //Arrange
             Mock<ISplitSdkApiClient> apiMock = new Mock<ISplitSdkApiClient>();
@@ -25,7 +25,7 @@ namespace Splitio_Tests.Unit_Tests
             ApiSplitChangeFetcher apiSplitChangeFetcher = new ApiSplitChangeFetcher(apiMock.Object);
 
             //Act
-            var result = apiSplitChangeFetcher.Fetch(-1);
+            var result = await apiSplitChangeFetcher.Fetch(-1);
 
             //Assert
             Assert.IsTrue(result != null);
@@ -33,7 +33,7 @@ namespace Splitio_Tests.Unit_Tests
         }
 
         [TestMethod]
-        public void FetchSplitChangesSuccessfull()
+        public async void FetchSplitChangesSuccessfull()
         {
             //Arrange
             var apiClient = new Mock<ISplitSdkApiClient>();
@@ -88,7 +88,7 @@ namespace Splitio_Tests.Unit_Tests
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
-            var result = apiFetcher.Fetch(-1);
+            var result = await apiFetcher.Fetch(-1);
 
             //Assert
             Assert.IsNotNull(result);
@@ -105,7 +105,7 @@ namespace Splitio_Tests.Unit_Tests
         }
 
         [TestMethod]
-        public void FetchSplitChangesSuccessfullVerifyAlgorithmIsLegacy()
+        public async void FetchSplitChangesSuccessfullVerifyAlgorithmIsLegacy()
         {
             //Arrange
             var apiClient = new Mock<ISplitSdkApiClient>();
@@ -161,7 +161,7 @@ namespace Splitio_Tests.Unit_Tests
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
-            var result = apiFetcher.Fetch(-1);
+            var result = await apiFetcher.Fetch(-1);
 
             //Assert
             Assert.IsNotNull(result);
@@ -170,7 +170,7 @@ namespace Splitio_Tests.Unit_Tests
         }
 
         [TestMethod]
-        public void FetchSplitChangesSuccessfullVerifyAlgorithmIsMurmur()
+        public async void FetchSplitChangesSuccessfullVerifyAlgorithmIsMurmur()
         {
             //Arrange
             var apiClient = new Mock<ISplitSdkApiClient>();
@@ -226,7 +226,7 @@ namespace Splitio_Tests.Unit_Tests
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
-            var result = apiFetcher.Fetch(-1);
+            var result = await apiFetcher.Fetch(-1);
 
             //Assert
             Assert.IsNotNull(result);

--- a/Net SDK Unit Tests/Unit Tests/SplitFetcher/ApiSplitChangeFetcherTests.cs
+++ b/Net SDK Unit Tests/Unit Tests/SplitFetcher/ApiSplitChangeFetcherTests.cs
@@ -235,7 +235,7 @@ namespace Splitio_Tests.Unit_Tests
         }
 
         [TestMethod]
-        public void FetchSplitChangesWithExcepionSouldReturnNull()
+        public async void FetchSplitChangesWithExcepionSouldReturnNull()
         {
             var apiClient = new Mock<ISplitSdkApiClient>();
             apiClient
@@ -244,7 +244,7 @@ namespace Splitio_Tests.Unit_Tests
             var apiFetcher = new ApiSplitChangeFetcher(apiClient.Object);
 
             //Act
-            var result = apiFetcher.Fetch(-1);
+            var result = await apiFetcher.Fetch(-1);
 
             //Assert
             Assert.IsNull(result);

--- a/Net SDK Unit Tests/packages.config
+++ b/Net SDK Unit Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Moq" version="4.0.10827" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
   <package id="StackExchange.Redis" version="1.2.1" targetFramework="net40" />

--- a/NetSDK/CommonLibraries/HTTPHeader.cs
+++ b/NetSDK/CommonLibraries/HTTPHeader.cs
@@ -8,6 +8,5 @@ namespace Splitio.CommonLibraries
         public string splitSDKSpecVersion { get; set; }
         public string splitSDKMachineName { get; set; }
         public string splitSDKMachineIP { get; set; }
-        public string encoding { get; set; } 
     }
 }

--- a/NetSDK/CommonLibraries/ISdkApiClient.cs
+++ b/NetSDK/CommonLibraries/ISdkApiClient.cs
@@ -1,10 +1,12 @@
 ﻿
+using System.Threading.Tasks;
+
 namespace Splitio.CommonLibraries
 {
     public interface ISdkApiClient
     {
-        HTTPResult ExecuteGet(string requestUri);
+        Task<HTTPResult> ExecuteGet(string requestUri);
 
-        HTTPResult ExecutePost(string requestUri, string data);
+        Task<HTTPResult> ExecutePost(string requestUri, string data);
     }
 }

--- a/NetSDK/CommonLibraries/ISdkApiClient.cs
+++ b/NetSDK/CommonLibraries/ISdkApiClient.cs
@@ -1,12 +1,12 @@
-﻿
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace Splitio.CommonLibraries
 {
     public interface ISdkApiClient
     {
-        Task<HTTPResult> ExecuteGet(string requestUri);
+        Task<HTTPResult> ExecuteGet(string requestUri, CancellationToken token = default(CancellationToken));
 
-        Task<HTTPResult> ExecutePost(string requestUri, string data);
+        Task<HTTPResult> ExecutePost(string requestUri, string data, CancellationToken token = default(CancellationToken));
     }
 }

--- a/NetSDK/CommonLibraries/SdkApiClient.cs
+++ b/NetSDK/CommonLibraries/SdkApiClient.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Splitio.CommonLibraries
@@ -46,12 +47,12 @@ namespace Splitio.CommonLibraries
             this.metricsLog = metricsLog;
         }
 
-        public virtual async Task<HTTPResult> ExecuteGet(string requestUri)
+        public virtual async Task<HTTPResult> ExecuteGet(string requestUri, CancellationToken token = default(CancellationToken))
         {
             var result = new HTTPResult();
             try
             {
-                using (var response = await httpClient.GetAsync(requestUri))
+                using (var response = await httpClient.GetAsync(requestUri, token))
                 { 
                     result.statusCode = response.StatusCode;
                     result.content = response.Content.ReadAsStringAsync().Result;
@@ -64,12 +65,12 @@ namespace Splitio.CommonLibraries
             return result;
         }
 
-        public virtual async Task<HTTPResult> ExecutePost(string requestUri, string data)
+        public virtual async Task<HTTPResult> ExecutePost(string requestUri, string data, CancellationToken token = default(CancellationToken))
         {
             var result = new HTTPResult();
             try
             {
-                using (var response = await httpClient.PostAsync(requestUri, new StringContent(data, Encoding.UTF8, "application/json")))
+                using (var response = await httpClient.PostAsync(requestUri, new StringContent(data, Encoding.UTF8, "application/json"), token))
                 { 
                     result.statusCode = response.StatusCode;
                     result.content = response.Content.ReadAsStringAsync().Result;

--- a/NetSDK/CommonLibraries/SdkApiClient.cs
+++ b/NetSDK/CommonLibraries/SdkApiClient.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Splitio.CommonLibraries
 {
@@ -17,18 +18,11 @@ namespace Splitio.CommonLibraries
         public SdkApiClient (HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null)
         {
             ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
-            if (header.encoding == "gzip")
+            var handler = new HttpClientHandler()
             {
-                HttpClientHandler handler = new HttpClientHandler()
-                {
-                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-                };
-                httpClient = new HttpClient(handler);
-            }
-            else
-            {
-                httpClient = new HttpClient();
-            }
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            };
+            httpClient = new HttpClient(handler);
 
             httpClient.BaseAddress = new Uri(baseUrl);
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", header.authorizationApiKey);
@@ -42,7 +36,7 @@ namespace Splitio.CommonLibraries
             {
                 httpClient.DefaultRequestHeaders.Add("SplitSDKMachineIP", header.splitSDKMachineIP);
             }
-            httpClient.DefaultRequestHeaders.Add("Accept-Encoding", header.encoding);
+            httpClient.DefaultRequestHeaders.Add("Accept-Encoding", "gzip");
             httpClient.DefaultRequestHeaders.Add("Keep-Alive", "true");
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
@@ -52,16 +46,16 @@ namespace Splitio.CommonLibraries
             this.metricsLog = metricsLog;
         }
 
-        public virtual HTTPResult ExecuteGet(string requestUri)
+        public virtual async Task<HTTPResult> ExecuteGet(string requestUri)
         {
             var result = new HTTPResult();
             try
             {
-                var task = httpClient.GetAsync(requestUri);
-                task.Wait();
-                var response = task.Result;
-                result.statusCode = response.StatusCode;
-                result.content = response.Content.ReadAsStringAsync().Result;                
+                using (var response = await httpClient.GetAsync(requestUri))
+                { 
+                    result.statusCode = response.StatusCode;
+                    result.content = response.Content.ReadAsStringAsync().Result;
+                }
             }
             catch(Exception e)
             {
@@ -70,16 +64,16 @@ namespace Splitio.CommonLibraries
             return result;
         }
 
-        public virtual HTTPResult ExecutePost(string requestUri, string data)
+        public virtual async Task<HTTPResult> ExecutePost(string requestUri, string data)
         {
             var result = new HTTPResult();
             try
             {
-                var task = httpClient.PostAsync(requestUri, new StringContent(data, Encoding.UTF8, "application/json"));
-                task.Wait();
-                var response = task.Result;
-                result.statusCode = response.StatusCode;
-                result.content = response.Content.ReadAsStringAsync().Result;
+                using (var response = await httpClient.PostAsync(requestUri, new StringContent(data, Encoding.UTF8, "application/json")))
+                { 
+                    result.statusCode = response.StatusCode;
+                    result.content = response.Content.ReadAsStringAsync().Result;
+                }
             }
             catch (Exception e)
             {

--- a/NetSDK/Services/Client/Classes/JSONFileClient.cs
+++ b/NetSDK/Services/Client/Classes/JSONFileClient.cs
@@ -21,7 +21,9 @@ namespace Splitio.Services.Client.Classes
             var segmentFetcher = new JSONFileSegmentFetcher(segmentsFilePath, segmentCache);
             var splitParser = new InMemorySplitParser(segmentFetcher, segmentCache);
             var splitChangeFetcher = new JSONFileSplitChangeFetcher(splitsFilePath);
-            var splitChangesResult = splitChangeFetcher.Fetch(-1);
+            var task = splitChangeFetcher.Fetch(-1);
+            task.Wait();
+            var splitChangesResult = task.Result;
             var parsedSplits = new ConcurrentDictionary<string, ParsedSplit>();
             foreach (Split split in splitChangesResult.splits)
                 parsedSplits.TryAdd(split.name, splitParser.Parse(split));         

--- a/NetSDK/Services/Client/Classes/SelfRefreshingClient.cs
+++ b/NetSDK/Services/Client/Classes/SelfRefreshingClient.cs
@@ -31,7 +31,6 @@ namespace Splitio.Services.Client.Classes
         private static string BaseUrl;
         private static int SplitsRefreshRate;
         private static int SegmentRefreshRate;
-        private static string HttpEncoding;
         private static long HttpConnectionTimeout;
         private static long HttpReadTimeout;
         private static string SdkVersion;
@@ -95,7 +94,6 @@ namespace Splitio.Services.Client.Classes
             EventsBaseUrl = String.IsNullOrEmpty(config.EventsEndpoint) ? "https://events.split.io" : config.EventsEndpoint;
             SplitsRefreshRate = config.FeaturesRefreshRate ?? 60;
             SegmentRefreshRate = config.SegmentsRefreshRate ?? 60;
-            HttpEncoding = "gzip";
             HttpConnectionTimeout = config.ConnectionTimeout ?? 15000;
             HttpReadTimeout = config.ReadTimeout ?? 15000;
             SdkVersion = ".NET-" + Version.SplitSdkVersion;
@@ -236,7 +234,6 @@ namespace Splitio.Services.Client.Classes
         {
             var header = new HTTPHeader();
             header.authorizationApiKey = ApiKey;
-            header.encoding = HttpEncoding;
             header.splitSDKVersion = SdkVersion;
             header.splitSDKSpecVersion = SdkSpecVersion;
             header.splitSDKMachineName = SdkMachineName;

--- a/NetSDK/Services/Events/Classes/EventSdkApiClient.cs
+++ b/NetSDK/Services/Events/Classes/EventSdkApiClient.cs
@@ -16,14 +16,14 @@ namespace Splitio.Services.Events.Classes
 
         public EventSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) : base(header, baseUrl, connectionTimeOut, readTimeout) { }
 
-        public void SendBulkEvents(List<Event> events)
+        public async void SendBulkEvents(List<Event> events)
         {
             var eventsJson = JsonConvert.SerializeObject(events, new JsonSerializerSettings
             {
                 NullValueHandling = NullValueHandling.Ignore
             });
 
-            var response = ExecutePost(EventsUrlTemplate, eventsJson);
+            var response = await ExecutePost(EventsUrlTemplate, eventsJson);
             if (response.statusCode != HttpStatusCode.OK)
             {
                 Log.Error(string.Format("Http status executing SendBulkEvents: {0} - {1}", response.statusCode.ToString(), response.content));

--- a/NetSDK/Services/Impressions/Classes/TreatmentSdkApiClient.cs
+++ b/NetSDK/Services/Impressions/Classes/TreatmentSdkApiClient.cs
@@ -18,11 +18,11 @@ namespace Splitio.Services.Impressions.Classes
 
         public TreatmentSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) : base(header, baseUrl, connectionTimeOut, readTimeout) { }
 
-        public void SendBulkImpressions(List<KeyImpression> impressions)
+        public async void SendBulkImpressions(List<KeyImpression> impressions)
         {
             var impressionsJson = ConvertToJson(impressions);
 
-            var response = ExecutePost(TestImpressionsUrlTemplate, impressionsJson);
+            var response = await ExecutePost(TestImpressionsUrlTemplate, impressionsJson);
             if (response.statusCode != HttpStatusCode.OK)
             {
                 Log.Error(String.Format("Http status executing SendBulkImpressions: {0} - {1}", response.statusCode.ToString(), response.content));

--- a/NetSDK/Services/Metrics/Classes/MetricsSdkApiClient.cs
+++ b/NetSDK/Services/Metrics/Classes/MetricsSdkApiClient.cs
@@ -14,27 +14,27 @@ namespace Splitio.Services.Metrics.Classes
 
         public MetricsSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout) : base(header, baseUrl, connectionTimeOut, readTimeout) { }
 
-        public void SendCountMetrics(string metrics)
+        public async void SendCountMetrics(string metrics)
         {
-            var response = ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "counters"), metrics);
+            var response = await ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "counters"), metrics);
             if (response.statusCode != HttpStatusCode.OK)
             {
                 Log.Error(String.Format("Http status executing SendCountMetrics: {0} - {1}", response.statusCode.ToString(), response.content));
             }
         }
 
-        public void SendTimeMetrics(string metrics)
+        public async void SendTimeMetrics(string metrics)
         {
-            var response = ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "times"), metrics);
+            var response = await ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "times"), metrics);
             if (response.statusCode != HttpStatusCode.OK)
             {
                 Log.Error(String.Format("Http status executing SendTimeMetrics: {0} - {1}", response.statusCode.ToString(), response.content));
             }
         }
 
-        public void SendGaugeMetrics(string metrics)
+        public async void SendGaugeMetrics(string metrics)
         {
-            var response = ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "gauge"), metrics);
+            var response = await ExecutePost(MetricsUrlTemplate.Replace("{endpoint}", "gauge"), metrics);
             if (response.statusCode != HttpStatusCode.OK)
             {
                 Log.Error(String.Format("Http status executing SendGaugeMetrics: {0} - {1}", response.statusCode.ToString(), response.content));

--- a/NetSDK/Services/SegmentFetcher/Classes/ApiSegmentChangeFetcher.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/ApiSegmentChangeFetcher.cs
@@ -2,6 +2,7 @@
 using Splitio.Services.SplitFetcher.Interfaces;
 using Newtonsoft.Json;
 using Splitio.Services.SegmentFetcher.Interfaces;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Classes
 {
@@ -14,9 +15,9 @@ namespace Splitio.Services.SegmentFetcher.Classes
             this.apiClient = apiClient;
         }
 
-        protected override SegmentChange FetchFromBackend(string name, long since)
+        protected override async Task<SegmentChange> FetchFromBackend(string name, long since)
         {
-            var fetchResult = apiClient.FetchSegmentChanges(name, since);
+            var fetchResult = await apiClient.FetchSegmentChanges(name, since);
 
             var segmentChange = JsonConvert.DeserializeObject<SegmentChange>(fetchResult);
             return segmentChange;

--- a/NetSDK/Services/SegmentFetcher/Classes/ApiSegmentChangeFetcher.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/ApiSegmentChangeFetcher.cs
@@ -3,6 +3,7 @@ using Splitio.Services.SplitFetcher.Interfaces;
 using Newtonsoft.Json;
 using Splitio.Services.SegmentFetcher.Interfaces;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Splitio.Services.SegmentFetcher.Classes
 {
@@ -15,9 +16,9 @@ namespace Splitio.Services.SegmentFetcher.Classes
             this.apiClient = apiClient;
         }
 
-        protected override async Task<SegmentChange> FetchFromBackend(string name, long since)
+        protected override async Task<SegmentChange> FetchFromBackend(string name, long since, CancellationToken token)
         {
-            var fetchResult = await apiClient.FetchSegmentChanges(name, since);
+            var fetchResult = await apiClient.FetchSegmentChanges(name, since, token);
 
             var segmentChange = JsonConvert.DeserializeObject<SegmentChange>(fetchResult);
             return segmentChange;

--- a/NetSDK/Services/SegmentFetcher/Classes/SegmentChangeFetcher.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SegmentChangeFetcher.cs
@@ -2,6 +2,7 @@
 using Splitio.Domain;
 using Splitio.Services.SegmentFetcher.Interfaces;
 using System;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Classes
 {
@@ -10,13 +11,13 @@ namespace Splitio.Services.SegmentFetcher.Classes
         private SegmentChange segmentChange;
         private static readonly ILog Log = LogManager.GetLogger(typeof(SegmentChangeFetcher));
 
-        protected abstract SegmentChange FetchFromBackend(string name, long since);
+        protected abstract Task<SegmentChange> FetchFromBackend(string name, long since);
 
-        public SegmentChange Fetch(string name, long since)
+        public async Task<SegmentChange> Fetch(string name, long since)
         {
             try
             {
-                segmentChange = FetchFromBackend(name, since);
+                segmentChange = await FetchFromBackend(name, since);
             }
             catch(Exception e)
             {

--- a/NetSDK/Services/SegmentFetcher/Classes/SegmentChangeFetcher.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SegmentChangeFetcher.cs
@@ -2,6 +2,7 @@
 using Splitio.Domain;
 using Splitio.Services.SegmentFetcher.Interfaces;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Classes
@@ -11,13 +12,13 @@ namespace Splitio.Services.SegmentFetcher.Classes
         private SegmentChange segmentChange;
         private static readonly ILog Log = LogManager.GetLogger(typeof(SegmentChangeFetcher));
 
-        protected abstract Task<SegmentChange> FetchFromBackend(string name, long since);
+        protected abstract Task<SegmentChange> FetchFromBackend(string name, long since, CancellationToken token = default(CancellationToken));
 
-        public async Task<SegmentChange> Fetch(string name, long since)
+        public async Task<SegmentChange> Fetch(string name, long since, CancellationToken token = default(CancellationToken))
         {
             try
             {
-                segmentChange = await FetchFromBackend(name, since);
+                segmentChange = await FetchFromBackend(name, since, token);
             }
             catch(Exception e)
             {

--- a/NetSDK/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
@@ -5,6 +5,7 @@ using Splitio.Services.SplitFetcher.Interfaces;
 using Common.Logging;
 using Splitio.Services.Metrics.Interfaces;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Classes
 {
@@ -18,16 +19,19 @@ namespace Splitio.Services.SegmentFetcher.Classes
 
         private static readonly ILog Log = LogManager.GetLogger(typeof(SegmentSdkApiClient));
 
-        public SegmentSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null) : base(header, baseUrl, connectionTimeOut, readTimeout, metricsLog) { }
+        public SegmentSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null) : base(header, baseUrl, connectionTimeOut, readTimeout, metricsLog)
+        {
+            Log.Debug($"SegmentSdkApiClient created");
+        }
 
-        public string FetchSegmentChanges(string name, long since)
+        public async Task<string> FetchSegmentChanges(string name, long since)
         {
             var clock = new Stopwatch();
             clock.Start();
             try
             {
                 var requestUri = GetRequestUri(name, since);
-                var response = ExecuteGet(requestUri);
+                var response = await ExecuteGet(requestUri);
                 if (response.statusCode == HttpStatusCode.OK)
                 {
                     if (metricsLog != null)
@@ -36,6 +40,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
                         metricsLog.Count(String.Format(SegmentFetcherStatus, response.statusCode), 1);
                     }
 
+                    Log.Debug($"FetchSegmentChanges with name '{name}' took {clock.ElapsedMilliseconds} milliseconds using uri '{requestUri}'");
                     return response.content;
                 }
                 else

--- a/NetSDK/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SegmentSdkApiClient.cs
@@ -6,6 +6,7 @@ using Common.Logging;
 using Splitio.Services.Metrics.Interfaces;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Splitio.Services.SegmentFetcher.Classes
 {
@@ -19,19 +20,16 @@ namespace Splitio.Services.SegmentFetcher.Classes
 
         private static readonly ILog Log = LogManager.GetLogger(typeof(SegmentSdkApiClient));
 
-        public SegmentSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null) : base(header, baseUrl, connectionTimeOut, readTimeout, metricsLog)
-        {
-            Log.Debug($"SegmentSdkApiClient created");
-        }
+        public SegmentSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null) : base(header, baseUrl, connectionTimeOut, readTimeout, metricsLog) { }
 
-        public async Task<string> FetchSegmentChanges(string name, long since)
+        public async Task<string> FetchSegmentChanges(string name, long since, CancellationToken token)
         {
             var clock = new Stopwatch();
             clock.Start();
             try
             {
                 var requestUri = GetRequestUri(name, since);
-                var response = await ExecuteGet(requestUri);
+                var response = await ExecuteGet(requestUri, token);
                 if (response.statusCode == HttpStatusCode.OK)
                 {
                     if (metricsLog != null)

--- a/NetSDK/Services/SegmentFetcher/Classes/SegmentTaskWorker.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SegmentTaskWorker.cs
@@ -44,8 +44,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
                     {
                         Log.Info(String.Format("Segment dequeued: {0}", segment.name));
                         IncrementCounter();
-                        // TODO: use cancellation token
-                        segment.RefreshSegment().ContinueWith((x) => { DecrementCounter(); });
+                        segment.RefreshSegment(token).ContinueWith((x) => { DecrementCounter(); });
                     }
                 }
                 else

--- a/NetSDK/Services/SegmentFetcher/Classes/SegmentTaskWorker.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SegmentTaskWorker.cs
@@ -44,9 +44,8 @@ namespace Splitio.Services.SegmentFetcher.Classes
                     {
                         Log.Info(String.Format("Segment dequeued: {0}", segment.name));
                         IncrementCounter();
-                        Task task = new Task(() => segment.RefreshSegment(), token);
-                        task.ContinueWith((x) => { DecrementCounter(); }); 
-                        task.Start();                   
+                        // TODO: use cancellation token
+                        segment.RefreshSegment().ContinueWith((x) => { DecrementCounter(); });
                     }
                 }
                 else

--- a/NetSDK/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
@@ -1,9 +1,9 @@
 ﻿using Common.Logging;
 using Splitio.Services.Cache.Interfaces;
-using Splitio.Services.Client.Classes;
 using Splitio.Services.SegmentFetcher.Interfaces;
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Classes
@@ -30,7 +30,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
             gates.RegisterSegment(name);
         }
 
-        public async Task RefreshSegment()
+        public async Task RefreshSegment(CancellationToken token = default(CancellationToken))
         {        
             while (true)
             {
@@ -38,7 +38,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
 
                 try
                 {
-                    var response = await segmentChangeFetcher.Fetch(name, changeNumber);
+                    var response = await segmentChangeFetcher.Fetch(name, changeNumber, token);
                     if (response == null)
                     {
                         break;

--- a/NetSDK/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SelfRefreshingSegment.cs
@@ -4,6 +4,7 @@ using Splitio.Services.Client.Classes;
 using Splitio.Services.SegmentFetcher.Interfaces;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Classes
 {
@@ -22,10 +23,14 @@ namespace Splitio.Services.SegmentFetcher.Classes
             this.segmentChangeFetcher = segmentChangeFetcher;
             this.segmentCache = segmentCache;
             this.gates = gates;
+        }
+
+        public void RegisterSegment()
+        {
             gates.RegisterSegment(name);
         }
 
-        public void RefreshSegment()
+        public async Task RefreshSegment()
         {        
             while (true)
             {
@@ -33,7 +38,7 @@ namespace Splitio.Services.SegmentFetcher.Classes
 
                 try
                 {
-                    var response = segmentChangeFetcher.Fetch(name, changeNumber);
+                    var response = await segmentChangeFetcher.Fetch(name, changeNumber);
                     if (response == null)
                     {
                         break;

--- a/NetSDK/Services/SegmentFetcher/Classes/SelfRefreshingSegmentFetcher.cs
+++ b/NetSDK/Services/SegmentFetcher/Classes/SelfRefreshingSegmentFetcher.cs
@@ -58,12 +58,10 @@ namespace Splitio.Services.SegmentFetcher.Classes
 
         public override void InitializeSegment(string name)
         {
-            SelfRefreshingSegment segment;
-            segments.TryGetValue(name, out segment);
-            if (segment == null)
+            var segment = new SelfRefreshingSegment(name, segmentChangeFetcher, gates, segmentCache);
+            if (segments.TryAdd(name, segment))
             {
-                segment = new SelfRefreshingSegment(name, segmentChangeFetcher, gates, segmentCache);
-                segments.TryAdd(name, segment);
+                segment.RegisterSegment();
                 SegmentTaskQueue.segmentsQueue.TryAdd(segment);
                 Log.Info(String.Format("Segment queued: {0}", segment.name));
             }

--- a/NetSDK/Services/SegmentFetcher/Interfaces/ISegmentChangeFetcher.cs
+++ b/NetSDK/Services/SegmentFetcher/Interfaces/ISegmentChangeFetcher.cs
@@ -1,9 +1,10 @@
 ﻿using Splitio.Domain;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Interfaces
 {
     public interface ISegmentChangeFetcher
     {
-        SegmentChange Fetch(string name, long change_number);
+        Task<SegmentChange> Fetch(string name, long change_number);
     }
 }

--- a/NetSDK/Services/SegmentFetcher/Interfaces/ISegmentChangeFetcher.cs
+++ b/NetSDK/Services/SegmentFetcher/Interfaces/ISegmentChangeFetcher.cs
@@ -1,10 +1,11 @@
 ﻿using Splitio.Domain;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Splitio.Services.SegmentFetcher.Interfaces
 {
     public interface ISegmentChangeFetcher
     {
-        Task<SegmentChange> Fetch(string name, long change_number);
+        Task<SegmentChange> Fetch(string name, long change_number, CancellationToken token = default(CancellationToken));
     }
 }

--- a/NetSDK/Services/SegmentFetcher/Interfaces/ISegmentSdkApiClient.cs
+++ b/NetSDK/Services/SegmentFetcher/Interfaces/ISegmentSdkApiClient.cs
@@ -1,10 +1,11 @@
 ﻿
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Interfaces
 {
     public interface ISegmentSdkApiClient
     {
-        Task<string> FetchSegmentChanges(string name, long since);
+        Task<string> FetchSegmentChanges(string name, long since, CancellationToken token = default(CancellationToken));
     }
 }

--- a/NetSDK/Services/SegmentFetcher/Interfaces/ISegmentSdkApiClient.cs
+++ b/NetSDK/Services/SegmentFetcher/Interfaces/ISegmentSdkApiClient.cs
@@ -1,8 +1,10 @@
 ﻿
+using System.Threading.Tasks;
+
 namespace Splitio.Services.SplitFetcher.Interfaces
 {
     public interface ISegmentSdkApiClient
     {
-        string FetchSegmentChanges(string name, long since);
+        Task<string> FetchSegmentChanges(string name, long since);
     }
 }

--- a/NetSDK/Services/SplitFetcher/Classes/ApiSplitChangeFetcher.cs
+++ b/NetSDK/Services/SplitFetcher/Classes/ApiSplitChangeFetcher.cs
@@ -15,9 +15,10 @@ namespace Splitio.Services.SplitFetcher.Classes
 
         protected override SplitChangesResult FetchFromBackend(long since)
         {
-            var fetchResult = apiClient.FetchSplitChanges(since);
+            var fetchResultTask = apiClient.FetchSplitChanges(since);
+            fetchResultTask.Wait();
 
-            var splitChangesResult = JsonConvert.DeserializeObject<SplitChangesResult>(fetchResult);
+            var splitChangesResult = JsonConvert.DeserializeObject<SplitChangesResult>(fetchResultTask.Result);
             return splitChangesResult;
         }
     }

--- a/NetSDK/Services/SplitFetcher/Classes/ApiSplitChangeFetcher.cs
+++ b/NetSDK/Services/SplitFetcher/Classes/ApiSplitChangeFetcher.cs
@@ -1,6 +1,7 @@
 ﻿using Splitio.Domain;
 using Splitio.Services.SplitFetcher.Interfaces;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Classes
 {
@@ -13,12 +14,11 @@ namespace Splitio.Services.SplitFetcher.Classes
             this.apiClient = apiClient;
         }
 
-        protected override SplitChangesResult FetchFromBackend(long since)
+        protected override async Task<SplitChangesResult> FetchFromBackend(long since)
         {
-            var fetchResultTask = apiClient.FetchSplitChanges(since);
-            fetchResultTask.Wait();
+            var fetchResult = await apiClient.FetchSplitChanges(since);
 
-            var splitChangesResult = JsonConvert.DeserializeObject<SplitChangesResult>(fetchResultTask.Result);
+            var splitChangesResult = JsonConvert.DeserializeObject<SplitChangesResult>(fetchResult);
             return splitChangesResult;
         }
     }

--- a/NetSDK/Services/SplitFetcher/Classes/JSONFileSplitChangeFetcher.cs
+++ b/NetSDK/Services/SplitFetcher/Classes/JSONFileSplitChangeFetcher.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using System.IO;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.SplitFetcher.Interfaces;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Classes
 {
@@ -15,11 +16,11 @@ namespace Splitio.Services.SplitFetcher.Classes
             this.filePath = filePath;
         }
 
-        protected override SplitChangesResult FetchFromBackend(long since)
+        protected override async Task<SplitChangesResult> FetchFromBackend(long since)
         {
             var json = File.ReadAllText(filePath);
             var splitChangesResult = JsonConvert.DeserializeObject<SplitChangesResult>(json);
-            return splitChangesResult;
+            return await TaskEx.FromResult(splitChangesResult);
         }
     }
 }

--- a/NetSDK/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
+++ b/NetSDK/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
@@ -2,7 +2,6 @@
 using Splitio.CommonLibraries;
 using Splitio.Domain;
 using Splitio.Services.Cache.Interfaces;
-using Splitio.Services.Client.Classes;
 using Splitio.Services.Parsing;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System;
@@ -93,14 +92,14 @@ namespace Splitio.Services.SplitFetcher.Classes
             }
         }
 
-        private void RefreshSplits()
+        private async void RefreshSplits()
         {
             while (true)
             {
                 var changeNumber = splitCache.GetChangeNumber();
                 try
                 {
-                    var result = splitChangeFetcher.Fetch(changeNumber);
+                    var result = await splitChangeFetcher.Fetch(changeNumber);
                     if (result == null)
                     {
                         break;

--- a/NetSDK/Services/SplitFetcher/Classes/SplitChangeFetcher.cs
+++ b/NetSDK/Services/SplitFetcher/Classes/SplitChangeFetcher.cs
@@ -2,6 +2,7 @@
 using Splitio.Domain;
 using Splitio.Services.SplitFetcher.Interfaces;
 using System;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Classes
 {
@@ -10,13 +11,13 @@ namespace Splitio.Services.SplitFetcher.Classes
         private SplitChangesResult splitChanges;
         private static readonly ILog Log = LogManager.GetLogger(typeof(SplitChangeFetcher));
 
-        protected abstract SplitChangesResult FetchFromBackend(long since);
+        protected abstract Task<SplitChangesResult> FetchFromBackend(long since);
 
-        public SplitChangesResult Fetch(long since)
+        public async Task<SplitChangesResult> Fetch(long since)
         {
             try
             {
-                splitChanges = FetchFromBackend(since);
+                splitChanges = await FetchFromBackend(since);
             }
             catch(Exception e)
             {

--- a/NetSDK/Services/SplitFetcher/Classes/SplitSdkApiClient.cs
+++ b/NetSDK/Services/SplitFetcher/Classes/SplitSdkApiClient.cs
@@ -5,6 +5,7 @@ using Splitio.Services.SplitFetcher.Interfaces;
 using Common.Logging;
 using Splitio.Services.Metrics.Interfaces;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Classes
 {
@@ -20,14 +21,14 @@ namespace Splitio.Services.SplitFetcher.Classes
 
         public SplitSdkApiClient(HTTPHeader header, string baseUrl, long connectionTimeOut, long readTimeout, IMetricsLog metricsLog = null) : base(header, baseUrl, connectionTimeOut, readTimeout, metricsLog) { }
 
-        public string FetchSplitChanges(long since)
+        public async Task<string> FetchSplitChanges(long since)
         {
             var clock = new Stopwatch();
             clock.Start();
             try
             {
                 var requestUri = GetRequestUri(since);
-                var response = ExecuteGet(requestUri);
+                var response = await ExecuteGet(requestUri);
                 if (response.statusCode == HttpStatusCode.OK)
                 {
                     if (metricsLog != null)

--- a/NetSDK/Services/SplitFetcher/Interfaces/ISplitChangeFetcher.cs
+++ b/NetSDK/Services/SplitFetcher/Interfaces/ISplitChangeFetcher.cs
@@ -1,9 +1,10 @@
 ﻿using Splitio.Domain;
+using System.Threading.Tasks;
 
 namespace Splitio.Services.SplitFetcher.Interfaces
 {
     public interface ISplitChangeFetcher
     {
-        SplitChangesResult Fetch(long since);
+        Task<SplitChangesResult> Fetch(long since);
     }
 }

--- a/NetSDK/Services/SplitFetcher/Interfaces/ISplitSdkApiClient.cs
+++ b/NetSDK/Services/SplitFetcher/Interfaces/ISplitSdkApiClient.cs
@@ -1,8 +1,10 @@
 ﻿
+using System.Threading.Tasks;
+
 namespace Splitio.Services.SplitFetcher.Interfaces
 {
     public interface ISplitSdkApiClient
     {
-        string FetchSplitChanges(long since);
+        Task<string> FetchSplitChanges(long since);
     }
 }

--- a/NetSDK/Splitio.csproj
+++ b/NetSDK/Splitio.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\sdk-test-app-template\Splitio.TestingApp\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,6 +41,15 @@
     <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="MurmurHash">
       <HintPath>..\packages\murmurhash.1.0.0\lib\net40\MurmurHash.dll</HintPath>
@@ -208,21 +219,19 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/NetSDK/packages.config
+++ b/NetSDK/packages.config
@@ -3,7 +3,8 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net40" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net40" />
   <package id="murmurhash" version="1.0.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />

--- a/Split.io.sln
+++ b/Split.io.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.9
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Splitio", "NetSDK\Splitio.csproj", "{357902E2-D685-4C14-8CCE-BD6CE7B22D36}"
 EndProject

--- a/Splitio.Redis/Splitio.Redis.csproj
+++ b/Splitio.Redis/Splitio.Redis.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -115,12 +117,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Splitio.Redis/packages.config
+++ b/Splitio.Redis/packages.config
@@ -4,7 +4,7 @@
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
   <package id="StackExchange.Redis" version="1.2.1" targetFramework="net40" />
 </packages>

--- a/Splitio.TestSupport/Splitio.TestSupport.csproj
+++ b/Splitio.TestSupport/Splitio.TestSupport.csproj
@@ -14,7 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>5d8ce85f</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -97,12 +98,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Splitio.TestSupport/packages.config
+++ b/Splitio.TestSupport/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net40" />


### PR DESCRIPTION
# Changes done
- Add reference to Microsoft.Bcl.Async
- Use async/await methods for API requests
- Change affected tests
- Remove unused `encoding` property since it was always hardcoded for using GZIP