### PR TITLE
Validate Traffic Types used in Track calls

### DIFF
--- a/Net SDK Unit Tests/Integration Tests/SelfRefreshingSplitFetcherTests.cs
+++ b/Net SDK Unit Tests/Integration Tests/SelfRefreshingSplitFetcherTests.cs
@@ -1,13 +1,12 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Splitio.CommonLibraries;
-using Splitio.Services.SplitFetcher.Classes;
 using Splitio.Domain;
-using Splitio.Services.Parsing;
-using Splitio.Services.SegmentFetcher.Classes;
-using Splitio.Services.Client.Classes;
 using Splitio.Services.Cache.Classes;
-using System.Collections.Concurrent;
+using Splitio.Services.Client.Classes;
 using Splitio.Services.Parsing.Classes;
+using Splitio.Services.SegmentFetcher.Classes;
+using Splitio.Services.SplitFetcher.Classes;
+using System.Collections.Concurrent;
 
 namespace Splitio_Tests.Integration_Tests
 {
@@ -27,7 +26,8 @@ namespace Splitio_Tests.Integration_Tests
             var splitChangesResult = splitChangeFetcher.Fetch(-1);
             var splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>());         
             var gates = new InMemoryReadinessGatesCache();
-            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(splitChangeFetcher, splitParser, gates, 30, splitCache);
+            var trafficTypeCache = new InMemoryTrafficTypesCache();
+            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(splitChangeFetcher, splitParser, gates, 30, trafficTypeCache, splitCache);
             selfRefreshingSplitFetcher.Start();
             gates.IsSDKReady(1000);
 
@@ -52,7 +52,8 @@ namespace Splitio_Tests.Integration_Tests
             var splitChangesResult = splitChangeFetcher.Fetch(-1);
             var splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>());
             var gates = new InMemoryReadinessGatesCache();
-            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(splitChangeFetcher, splitParser, gates, 30, splitCache);
+            var trafficTypeCache = new InMemoryTrafficTypesCache();
+            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(splitChangeFetcher, splitParser, gates, 30, trafficTypeCache, splitCache);
             selfRefreshingSplitFetcher.Start();
             gates.IsSDKReady(1000);
 
@@ -93,7 +94,8 @@ namespace Splitio_Tests.Integration_Tests
 
             var splitParser = new InMemorySplitParser(selfRefreshingSegmentFetcher, segmentCache);
             var splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>());
-            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(apiSplitChangeFetcher, splitParser, gates, 30, splitCache);
+            var trafficTypeCache = new InMemoryTrafficTypesCache();
+            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(apiSplitChangeFetcher, splitParser, gates, 30, trafficTypeCache, splitCache);
             selfRefreshingSplitFetcher.Start();
 
             //Act           
@@ -132,7 +134,8 @@ namespace Splitio_Tests.Integration_Tests
             var selfRefreshingSegmentFetcher = new SelfRefreshingSegmentFetcher(apiSegmentChangeFetcher, gates, 30, segmentCache, 4);
             var splitParser = new InMemorySplitParser(selfRefreshingSegmentFetcher, segmentCache);
             var splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>());
-            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(apiSplitChangeFetcher, splitParser, gates, 30, splitCache);
+            var trafficTypeCache = new InMemoryTrafficTypesCache();
+            var selfRefreshingSplitFetcher = new SelfRefreshingSplitFetcher(apiSplitChangeFetcher, splitParser, gates, 30, trafficTypeCache, splitCache);
             selfRefreshingSplitFetcher.Start();
 
             //Act

--- a/Net SDK Unit Tests/Unit Tests/Client/SplitClientForTesting.cs
+++ b/Net SDK Unit Tests/Unit Tests/Client/SplitClientForTesting.cs
@@ -9,18 +9,20 @@ namespace Splitio_Tests.Unit_Tests.Client
 {
     public class SplitClientForTesting : SplitClient
     {
-        public SplitClientForTesting(ILog log, ISplitCache _splitCache, Splitter _splitter, IListener<WrappedEvent> eventListener) 
+        public SplitClientForTesting(ILog log, 
+            ISplitCache _splitCache, 
+            Splitter _splitter, 
+            IListener<WrappedEvent> _eventListener,
+            ITrafficTypesCache _trafficTypesCache)
             : base(log)
         {
             splitCache = _splitCache;
             splitter = _splitter;
-            this.eventListener = eventListener;
+            trafficTypesCache = _trafficTypesCache;
+            eventListener = _eventListener;
         }
 
 
-        public override void Destroy()
-        {
-
-        }
+        public override void Destroy() {} 
     }
 }

--- a/Net SDK Unit Tests/Unit Tests/Client/SplitClientUnitTests.cs
+++ b/Net SDK Unit Tests/Unit Tests/Client/SplitClientUnitTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Splitio.Domain;
+using Splitio.Services.Cache.Classes;
 using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.Client.Interfaces;
 using Splitio.Services.EngineEvaluator;
@@ -18,6 +19,7 @@ namespace Splitio_Tests.Unit_Tests.Client
         private Mock<ISplitCache> _splitCacheMock;
         private Mock<Splitter> _splitterMock;
         private Mock<CombiningMatcher> _combiningMatcher;
+        private ITrafficTypesCache _trafficTypesCache;
 
         private SplitClientForTesting _splitClientForTesting;
 
@@ -29,8 +31,9 @@ namespace Splitio_Tests.Unit_Tests.Client
             _splitterMock = new Mock<Splitter>();
             _combiningMatcher = new Mock<CombiningMatcher>();
             _eventListenerMock = new Mock<IListener<WrappedEvent>>();
-            
-            _splitClientForTesting = new SplitClientForTesting(_logMock.Object, _splitCacheMock.Object, _splitterMock.Object, _eventListenerMock.Object);
+            _trafficTypesCache = new InMemoryTrafficTypesCache();
+
+            _splitClientForTesting = new SplitClientForTesting(_logMock.Object, _splitCacheMock.Object, _splitterMock.Object, _eventListenerMock.Object, _trafficTypesCache);
         }
 
         #region GetTreatment
@@ -531,6 +534,60 @@ namespace Splitio_Tests.Unit_Tests.Client
                                                                               && we.Event.eventTypeId.Equals("event_type")
                                                                               && we.Event.trafficTypeName.Equals("user")
                                                                               && we.Event.value == 132)), Times.Exactly(1));
+        }
+
+        [TestMethod]
+        public void Track_WhenTraffictTypeDoesNotExist_ReturnsTrue()
+        {
+            // Arrange.
+            var types = new List<string>();
+
+            for (int i = 0; i < 100; i++)
+            {
+                types.Add($"type_{i}");
+            }
+
+            _trafficTypesCache.Load(types);
+
+            // Act.
+            var result = _splitClientForTesting.Track("key", "traffict_type", "event_type", 132);
+
+            // Assert.
+            Assert.IsTrue(result);
+            _eventListenerMock.Verify(mock => mock.Log(It.Is<WrappedEvent>(we => we.Event.properties == null
+                                                                              && we.Event.key.Equals("key")
+                                                                              && we.Event.eventTypeId.Equals("event_type")
+                                                                              && we.Event.trafficTypeName.Equals("traffict_type")
+                                                                              && we.Event.value == 132)), Times.Exactly(1));
+
+            _logMock.Verify(mock => mock.Warn("Track: Traffic Type traffict_type does not have any corresponding Splits in this environment, make sure you’re tracking your events to a valid traffic type defined in the Split console."), Times.Exactly(1));
+        }
+
+        [TestMethod]
+        public void Track_WhenTraffictTypeExists_ReturnsTrue()
+        {
+            // Arrange.
+            var types = new List<string>();
+
+            for (int i = 0; i < 100; i++)
+            {
+                types.Add($"type_{i}");
+            }
+
+            _trafficTypesCache.Load(types);
+
+            // Act.
+            var result = _splitClientForTesting.Track("key", "type_10", "event_type", 132);
+
+            // Assert.
+            Assert.IsTrue(result);
+            _eventListenerMock.Verify(mock => mock.Log(It.Is<WrappedEvent>(we => we.Event.properties == null
+                                                                              && we.Event.key.Equals("key")
+                                                                              && we.Event.eventTypeId.Equals("event_type")
+                                                                              && we.Event.trafficTypeName.Equals("type_10")
+                                                                              && we.Event.value == 132)), Times.Exactly(1));
+
+            _logMock.Verify(mock => mock.Warn("Track: Traffic Type type_10 does not have any corresponding Splits in this environment, make sure you’re tracking your events to a valid traffic type defined in the Split console."), Times.Exactly(0));
         }
         #endregion
 

--- a/Net SDK Unit Tests/Unit Tests/InputValidation/TrafficTypeValidatorTests.cs
+++ b/Net SDK Unit Tests/Unit Tests/InputValidation/TrafficTypeValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using Common.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.InputValidation.Classes;
 
 namespace Splitio_Tests.Unit_Tests.InputValidation
@@ -9,14 +10,16 @@ namespace Splitio_Tests.Unit_Tests.InputValidation
     public class TrafficTypeValidatorTests
     {
         private Mock<ILog> _log;
+        private Mock<ITrafficTypesCache> _trafficTypesCache;
         private TrafficTypeValidator trafficTypeValidator;
 
         [TestInitialize]
         public void Initialize()
         {
             _log = new Mock<ILog>();
+            _trafficTypesCache = new Mock<ITrafficTypesCache>();
 
-            trafficTypeValidator = new TrafficTypeValidator(_log.Object);
+            trafficTypeValidator = new TrafficTypeValidator(_log.Object, _trafficTypesCache.Object); ;
         }
 
         [TestMethod]
@@ -32,6 +35,8 @@ namespace Splitio_Tests.Unit_Tests.InputValidation
             // Asserts.
             Assert.IsFalse(result.Success);
             _log.Verify(mock => mock.Error($"{method}: you passed a null traffic_type, traffic_type must be a non-empty string"), Times.Once());
+            _log.Verify(mock => mock.Error(It.IsAny<string>()), Times.Exactly(1));
+            _log.Verify(mock => mock.Warn(It.IsAny<string>()), Times.Exactly(0));
         }
 
         [TestMethod]
@@ -47,6 +52,8 @@ namespace Splitio_Tests.Unit_Tests.InputValidation
             // Asserts.
             Assert.IsFalse(result.Success);
             _log.Verify(mock => mock.Error($"{method}: you passed an empty traffic_type, traffic_type must be a non-empty string"), Times.Once());
+            _log.Verify(mock => mock.Error(It.IsAny<string>()), Times.Exactly(1));
+            _log.Verify(mock => mock.Warn(It.IsAny<string>()), Times.Exactly(0));
         }
         
         [TestMethod]
@@ -56,14 +63,42 @@ namespace Splitio_Tests.Unit_Tests.InputValidation
             string trafficType = "aBcDeFg";
             var method = "Tests";
 
+            _trafficTypesCache
+                .Setup(mock => mock.Exists(trafficType.ToLower()))
+                .Returns(true);
+
             // Act.
             var result = trafficTypeValidator.IsValid(trafficType, method);
 
             // Asserts.
             Assert.IsTrue(result.Success);
             Assert.AreNotEqual(trafficType, result.Value);
-            Assert.AreEqual("abcdefg", result.Value);
+            Assert.AreEqual(trafficType.ToLower(), result.Value);
             _log.Verify(mock => mock.Warn($"{method}: {trafficType} should be all lowercase - converting string to lowercase"), Times.Once());
+            _log.Verify(mock => mock.Warn(It.IsAny<string>()), Times.Exactly(1));
+            _log.Verify(mock => mock.Error(It.IsAny<string>()), Times.Exactly(0));
+        }
+
+        [TestMethod]
+        public void IsValid_WhenTrafficTypeDoesNotExist_ReturnsTrue()
+        {
+            // Arrange.
+            string trafficType = "traffict_type_test";
+            var method = "Tests";
+
+            _trafficTypesCache
+                .Setup(mock => mock.Exists(trafficType))
+                .Returns(false);
+
+            // Act.
+            var result = trafficTypeValidator.IsValid(trafficType, method);
+
+            // Asserts.
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(trafficType, result.Value);
+            _log.Verify(mock => mock.Warn($"Track: Traffic Type {trafficType} does not have any corresponding Splits in this environment, make sure you’re tracking your events to a valid traffic type defined in the Split console."), Times.Once());
+            _log.Verify(mock => mock.Warn(It.IsAny<string>()), Times.Exactly(1));
+            _log.Verify(mock => mock.Error(It.IsAny<string>()), Times.Exactly(0));
         }
     }
 }

--- a/NetSDK/Services/Cache/Classes/InMemoryTrafficTypesCache.cs
+++ b/NetSDK/Services/Cache/Classes/InMemoryTrafficTypesCache.cs
@@ -1,0 +1,38 @@
+﻿using Splitio.Services.Cache.Interfaces;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Splitio.Services.Cache.Classes
+{
+    public class InMemoryTrafficTypesCache : ITrafficTypesCache
+    {
+        private ConcurrentBag<string> _trafficTypes;
+
+        public InMemoryTrafficTypesCache()
+        {
+            _trafficTypes = new ConcurrentBag<string>();
+        }
+
+        public void Load(List<string> trafficTypes)
+        {
+            trafficTypes = trafficTypes.Distinct().ToList();
+
+            foreach (var type in trafficTypes)
+            {
+                if (!Exists(type))
+                    _trafficTypes.Add(type);
+            }
+        }
+
+        public void Clear()
+        {
+            _trafficTypes = new ConcurrentBag<string>();
+        }
+
+        public bool Exists(string trafficType)
+        {
+            return _trafficTypes.FirstOrDefault(tt => trafficType.Equals(tt)) != null;
+        }
+    }
+}

--- a/NetSDK/Services/Cache/Interfaces/ITrafficTypesCache.cs
+++ b/NetSDK/Services/Cache/Interfaces/ITrafficTypesCache.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Splitio.Services.Cache.Interfaces
+{
+    public interface ITrafficTypesCache
+    {
+        void Load(List<string> trafficTypes);
+        void Clear();
+        bool Exists(string trafficType);
+    }
+}

--- a/NetSDK/Services/Client/Classes/SelfRefreshingClient.cs
+++ b/NetSDK/Services/Client/Classes/SelfRefreshingClient.cs
@@ -196,8 +196,11 @@ namespace Splitio.Services.Client.Classes
             selfRefreshingSegmentFetcher = new SelfRefreshingSegmentFetcher(segmentChangeFetcher, gates, segmentRefreshRate, segmentCache, NumberOfParalellSegmentTasks);
             var splitChangeFetcher = new ApiSplitChangeFetcher(splitSdkApiClient);
             var splitParser = new InMemorySplitParser(selfRefreshingSegmentFetcher, segmentCache);
+
             splitCache = new InMemorySplitCache(new ConcurrentDictionary<string, ParsedSplit>(ConcurrencyLevel, InitialCapacity));
-            splitFetcher = new SelfRefreshingSplitFetcher(splitChangeFetcher, splitParser, gates, splitsRefreshRate, splitCache);
+            trafficTypesCache = new InMemoryTrafficTypesCache();
+
+            splitFetcher = new SelfRefreshingSplitFetcher(splitChangeFetcher, splitParser, gates, splitsRefreshRate, trafficTypesCache, splitCache);
         }
 
         private void BuildTreatmentLog(ConfigurationOptions config)

--- a/NetSDK/Services/Client/Classes/SplitClient.cs
+++ b/NetSDK/Services/Client/Classes/SplitClient.cs
@@ -22,7 +22,6 @@ namespace Splitio.Services.Client.Classes
         protected readonly IKeyValidator _keyValidator;
         protected readonly ISplitNameValidator _splitNameValidator;
         protected readonly IEventTypeValidator _eventTypeValidator;
-        protected readonly ITrafficTypeValidator _trafficTypeValidator;
         protected readonly IEventPropertiesValidator _eventPropertiesValidator;
         protected const string Control = "control";
         protected const string SdkGetTreatment = "sdk.getTreatment";
@@ -48,6 +47,8 @@ namespace Splitio.Services.Client.Classes
         protected ISimpleCache<WrappedEvent> eventsCache;
         protected ISplitCache splitCache;
         protected ISegmentCache segmentCache;
+        protected ITrafficTypesCache trafficTypesCache;
+        protected ITrafficTypeValidator _trafficTypeValidator;
 
         private ConcurrentDictionary<string, string> treatmentCache = new ConcurrentDictionary<string, string>();
 
@@ -57,7 +58,6 @@ namespace Splitio.Services.Client.Classes
             _keyValidator = new KeyValidator(_log);
             _splitNameValidator = new SplitNameValidator(_log);
             _eventTypeValidator = new EventTypeValidator(_log);
-            _trafficTypeValidator = new TrafficTypeValidator(_log);
             _eventPropertiesValidator = new EventPropertiesValidator(_log);
         }
 
@@ -128,6 +128,7 @@ namespace Splitio.Services.Client.Classes
         public virtual bool Track(string key, string trafficType, string eventType, double? value = null, Dictionary<string, object> properties = null)
         {
             CheckClientStatus();
+            _trafficTypeValidator = new TrafficTypeValidator(_log, trafficTypesCache);
 
             var keyResult = _keyValidator.IsValid(new Key(key, null), nameof(Track));
             var trafficTypeResult = _trafficTypeValidator.IsValid(trafficType, nameof(trafficType));

--- a/NetSDK/Services/InputValidation/Classes/TrafficTypeValidator.cs
+++ b/NetSDK/Services/InputValidation/Classes/TrafficTypeValidator.cs
@@ -1,5 +1,6 @@
 ﻿using Common.Logging;
 using Splitio.Domain;
+using Splitio.Services.Cache.Interfaces;
 using Splitio.Services.InputValidation.Interfaces;
 using System.Linq;
 
@@ -8,10 +9,13 @@ namespace Splitio.Services.InputValidation.Classes
     public class TrafficTypeValidator : ITrafficTypeValidator
     {
         protected readonly ILog _log;
+        private readonly ITrafficTypesCache _trafficTypesCache;
 
-        public TrafficTypeValidator(ILog log)
+        public TrafficTypeValidator(ILog log, 
+            ITrafficTypesCache trafficTypesCache)
         {
             _log = log;
+            _trafficTypesCache = trafficTypesCache;
         }
 
         public ValidatorResult IsValid(string trafficType, string method)
@@ -33,6 +37,11 @@ namespace Splitio.Services.InputValidation.Classes
                 _log.Warn($"{method}: {trafficType} should be all lowercase - converting string to lowercase");
 
                 trafficType = trafficType.ToLower();
+            }
+
+            if (!_trafficTypesCache.Exists(trafficType))
+            {
+                _log.Warn($"Track: Traffic Type {trafficType} does not have any corresponding Splits in this environment, make sure you’re tracking your events to a valid traffic type defined in the Split console.");
             }
 
             return new ValidatorResult { Success = true, Value = trafficType };

--- a/NetSDK/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
+++ b/NetSDK/Services/SplitFetcher/Classes/SelfRefreshingSplitFetcher.cs
@@ -14,87 +14,94 @@ namespace Splitio.Services.SplitFetcher.Classes
 {
     public class SelfRefreshingSplitFetcher
     {
-        protected readonly ISplitCache splitCache;
         private static readonly ILog Log = LogManager.GetLogger(typeof(SelfRefreshingSplitFetcher));
-        private readonly ISplitChangeFetcher splitChangeFetcher;
-        private readonly SplitParser splitParser;
-        private readonly int interval;
-        private readonly CancellationTokenSource cancelTokenSource = new CancellationTokenSource();
-        private readonly IReadinessGatesCache gates;
 
+        private readonly ISplitChangeFetcher _splitChangeFetcher;
+        private readonly IReadinessGatesCache _gates;
+        private readonly ITrafficTypesCache _trafficTypesCache;
+        private readonly ISplitCache _splitCache;
+        private readonly SplitParser _splitParser;
+        private readonly CancellationTokenSource _cancelTokenSource;
+        private readonly int interval;
 
         public SelfRefreshingSplitFetcher(ISplitChangeFetcher splitChangeFetcher,
-            SplitParser splitParser, IReadinessGatesCache gates, int interval, ISplitCache splitCache = null)
+            SplitParser splitParser, 
+            IReadinessGatesCache gates, 
+            int interval,
+            ITrafficTypesCache trafficTypesCache,
+            ISplitCache splitCache = null)
         {
-            this.splitChangeFetcher = splitChangeFetcher;
-            this.splitParser = splitParser;
-            this.gates = gates;
+            _cancelTokenSource = new CancellationTokenSource();
+            _splitChangeFetcher = splitChangeFetcher;
+            _splitParser = splitParser;
+            _gates = gates;
+            _trafficTypesCache = trafficTypesCache;
+            _splitCache = splitCache;
+
             this.interval = interval;
-            this.splitCache = splitCache;
         }
 
         public void Start()
         {
-            Task periodicTask = PeriodicTaskFactory.Start(() =>
-                                {
-                                    RefreshSplits();
-                                },
-                                intervalInMilliseconds: interval * 1000,
-                                cancelToken: cancelTokenSource.Token);
+            Task periodicTask = PeriodicTaskFactory
+                .Start(() =>
+                {
+                    RefreshSplits();
+                },
+                intervalInMilliseconds: interval * 1000,
+                cancelToken: _cancelTokenSource.Token);
         }
 
         public void Stop()
         {
-            cancelTokenSource.Cancel();
-            splitCache.Clear();
+            _cancelTokenSource.Cancel();
+            _splitCache.Clear();
         }
 
         private void UpdateSplitsFromChangeFetcherResponse(List<Split> splitChanges)
         {
-            List<Split> addedSplits = new List<Split>();
-            List<Split> removedSplits = new List<Split>();
+            var addedSplits = new List<Split>();
+            var removedSplits = new List<Split>();
 
-            foreach (Split split in splitChanges)
+            foreach (var split in splitChanges)
             {
-                ParsedSplit parsedSplit;
                 //If not active --> Remove Split
-                StatusEnum result;
-                var isValidStatus = Enum.TryParse(split.status, out result);
+                var isValidStatus = Enum.TryParse(split.status, out StatusEnum result);
+
                 if (!isValidStatus || result != StatusEnum.ACTIVE)
                 {
-                    splitCache.RemoveSplit(split.name);
+                    _splitCache.RemoveSplit(split.name);
                     removedSplits.Add(split);
                 }
                 else
                 {
                     //Test if its a new Split, remove if existing
-                    bool isRemoved = splitCache.RemoveSplit(split.name);
+                    var isRemoved = _splitCache.RemoveSplit(split.name);
 
                     if (!isRemoved)
                     {
                         //If not existing in _splits, its a new split
                         addedSplits.Add(split);
                     }
-                    parsedSplit = splitParser.Parse(split);
-                    splitCache.AddSplit(parsedSplit.name, parsedSplit);
+
+                    var parsedSplit = _splitParser.Parse(split);
+
+                    _splitCache.AddSplit(parsedSplit.name, parsedSplit);
                 }
             }
 
-            if (addedSplits.Count() > 0)
+            if (addedSplits.Count() > 0 && Log.IsDebugEnabled)
             {
                 var addedFeatureNames = addedSplits.Select(x => x.name).ToList();
-                if (Log.IsDebugEnabled)
-                {
-                    Log.Debug(String.Format("Added features: {0}", String.Join(" - ", addedFeatureNames)));
-                }
+
+                Log.Debug(string.Format("Added features: {0}", string.Join(" - ", addedFeatureNames)));
             }
-            if (removedSplits.Count() > 0)
+
+            if (removedSplits.Count() > 0 && Log.IsDebugEnabled)
             {
                 var removedFeatureNames = removedSplits.Select(x => x.name).ToList();
-                if (Log.IsDebugEnabled)
-                {
-                    Log.Debug(String.Format("Deleted features: {0}", String.Join(" - ", removedFeatureNames)));
-                }
+
+                Log.Debug(string.Format("Deleted features: {0}", string.Join(" - ", removedFeatureNames)));
             }
         }
 
@@ -102,24 +109,31 @@ namespace Splitio.Services.SplitFetcher.Classes
         {
             while (true)
             {
-                var changeNumber = splitCache.GetChangeNumber();
+                var changeNumber = _splitCache.GetChangeNumber();
+
                 try
                 {
-                    var result = await splitChangeFetcher.Fetch(changeNumber);
+                    var result = await _splitChangeFetcher.Fetch(changeNumber);
+
                     if (result == null)
                     {
                         break;
                     }
                     if (changeNumber >= result.till)
                     {
-                        gates.SplitsAreReady();
                         //There are no new split changes
+                        _gates.SplitsAreReady();                        
                         break;
                     }
                     if (result.splits != null && result.splits.Count > 0)
                     {
                         UpdateSplitsFromChangeFetcherResponse(result.splits);
-                        splitCache.SetChangeNumber(result.till);
+                        _splitCache.SetChangeNumber(result.till);
+
+                        var splits = _splitCache.GetAllSplits();
+
+                        _trafficTypesCache.Clear();
+                        _trafficTypesCache.Load(splits.Select(tt => ((ParsedSplit)tt).trafficTypeName).ToList());
                     }
                 }
                 catch (Exception e)
@@ -131,7 +145,7 @@ namespace Splitio.Services.SplitFetcher.Classes
                 {
                     if (Log.IsDebugEnabled)
                     {
-                        Log.Debug(String.Format("split fetch before: {0}, after: {1}", changeNumber, splitCache.GetChangeNumber()));
+                        Log.Debug(string.Format("split fetch before: {0}, after: {1}", changeNumber, _splitCache.GetChangeNumber()));
                     }
                 }
             }

--- a/NetSDK/Splitio.csproj
+++ b/NetSDK/Splitio.csproj
@@ -130,6 +130,8 @@
     <Compile Include="Domain\TreatmentResult.cs" />
     <Compile Include="Domain\ValidatorResult.cs" />
     <Compile Include="Domain\WrappedEvent.cs" />
+    <Compile Include="Services\Cache\Classes\InMemoryTrafficTypesCache.cs" />
+    <Compile Include="Services\Cache\Interfaces\ITrafficTypesCache.cs" />
     <Compile Include="Services\Events\Classes\EventSdkApiClient.cs" />
     <Compile Include="Services\Events\Classes\SelfUpdatingEventLog.cs" />
     <Compile Include="Services\Events\Interfaces\IEventSdkApiClient.cs" />


### PR DESCRIPTION
- Created a cache of all the Traffic Type that have been returned in the Split definitions that have come from /splitChanges
- Now we validate If the Traffic Type used in Track calls does not match we log a warning.